### PR TITLE
feat: add finalize method

### DIFF
--- a/R/DiseasyBaseModule.R
+++ b/R/DiseasyBaseModule.R
@@ -93,8 +93,22 @@ DiseasyBaseModule <- R6::R6Class( # nolint: object_name_linter
       # Finally, store the module
       private[[glue::glue(".{class(module)[1]}")]] <- module
 
-    }
+      # ... and track if module was cloned
+      attr(private[[glue::glue(".{class(module)[1]}")]], "clone") <- clone
 
+    },
+
+
+    #' @description
+    #'   Handles the cleanup of the class
+    finalize = function() {
+      # Look for contained Diseasy* classes and call finalize on these
+      private |>
+        as.list() |>
+        purrr::keep(~ inherits(., "DiseasyBaseModule")) |>
+        purrr::discard(~ isTRUE(attr(., "clone"))) |>
+        purrr::walk(~ .$finalize())
+    }
   ),
 
   active = list(

--- a/R/DiseasyObservables.R
+++ b/R/DiseasyObservables.R
@@ -213,6 +213,16 @@ DiseasyObservables <- R6::R6Class( # nolint: object_name_linter
       )
 
       printr(glue::glue("slice_date set to: {self$slice_date}"))
+    },
+
+
+    #' @description
+    #'   Handles the cleanup of the class
+    finalize = function() {
+
+      # Close the connection, then do rest of cleanup
+      if (DBI::dbIsValid(self$conn)) DBI::dbDisconnect(self$conn)
+      super$finalize()
     }
   ),
 


### PR DESCRIPTION
This PR adds a finalise method to the base class so cleanup can be handled more gracefully.
Specifically, the `DiseasyObservables` class has connection objects that should be closed when the object is deleted.

This PR adds a finalise method to the base class that first looks for nested "DiseasyBaseModule" objects within itself.
(i.e. when an instance of a `Diseasy*` module is stored within the object).
These nested objects are then asked to finalise as part of the parent is finalising, but only if the instance was not copied into the parent object during loading. If it was copied, the instance is still in use somewhere else and should not be cleaned up at this time. Instead, it will be cleaned up when the original instance (the one that was copied) is asked to finalise at some later point.
