### PR TITLE
test: add tests for return, examples and non_ascii

### DIFF
--- a/man/diseasy-package.Rd
+++ b/man/diseasy-package.Rd
@@ -4,11 +4,19 @@
 \name{diseasy-package}
 \alias{diseasy}
 \alias{diseasy-package}
-\title{diseasy: disease ensemble modelling made easy}
+\title{diseasy: Disease Ensemble Modelling Made Easy}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 This package facilitates creation of an ensemble of models through modular construction and combinatorics.
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/ssi-dk/diseasy}
+  \item Report bugs at \url{https://github.com/ssi-dk/diseasy/issues}
+}
+
 }
 \author{
 \strong{Maintainer}: Rasmus Skytte Randløv \email{rske@ssi.dk} (\href{https://orcid.org/0000-0002-5860-3838}{ORCID})

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,0 +1,35 @@
+test_that("Exported code has @examples", {
+  pkg_dir <- stringr::str_remove(getwd(), "/tests/testthat")
+
+  r_files  <- list.files(path = file.path(pkg_dir, "R"),   pattern = r"{\.[Rr]$}",     full.names = TRUE)
+
+  files_to_check <- r_files
+
+  for (file in files_to_check) {
+    lines <- readLines(file, warn = FALSE)
+
+    code_blocks <- lines |>
+      stringr::str_detect("^#'") |>
+      (\(.) . & !c(FALSE, .[-length(.)]))() |>
+      cumsum() |>
+      (\(.) split(lines, .))()
+
+    # Truncate
+    code_blocks <- purrr::map(code_blocks, ~ purrr::discard(., cumprod(stringr::str_detect(., "^$")) == 1))
+
+    # Look for @export tag
+    exported_code_blocks <- purrr::keep(code_blocks, ~ any(stringr::str_detect(., "@export")))
+
+    # Look for missing @examples tag
+    no_examples <- purrr::discard(exported_code_blocks, ~ any(stringr::str_detect(., "@example")))
+
+    # Report issues
+    for (block in no_examples) {
+      function_with_issue <- purrr::keep(block, ~ stringr::str_detect(., r"{(?<= <-) function\(}")) |>
+        stringr::str_extract(r"{^[\w\.%`]*(?= <-)}")
+
+      expect_true(any(stringr::str_detect(block, "@example")),
+                  label = glue::glue("{function_with_issue} is exported but has no @example(s)"))
+    }
+  }
+})

--- a/tests/testthat/test-non_ascii.R
+++ b/tests/testthat/test-non_ascii.R
@@ -1,0 +1,18 @@
+test_that("Code contains no non-ascii characters", {
+  pkg_dir <- stringr::str_remove(getwd(), "/tests/testthat")
+
+  r_files  <- list.files(path = file.path(pkg_dir, "R"),   pattern = r"{\.[Rr]$}",     full.names = TRUE)
+  rd_files <- list.files(path = file.path(pkg_dir, "man"), pattern = r"{\.[Rr][Dd]$}", full.names = TRUE)
+
+  files_to_check <- c(r_files, rd_files) |>
+    purrr::discard(~ stringr::str_detect(.x, "SCDB-package"))
+
+  for (file in files_to_check) {
+    lines <- readLines(file, warn = FALSE)
+    has_non_ascii <- any(grepl(r"{[^\x00-\x7f]}", lines, perl = TRUE))
+    if (has_non_ascii) {
+      print(grepl(r"{[^\x00-\x7f]}", lines, perl = TRUE))
+    }
+    expect_false(has_non_ascii, label = paste("File:", file))
+  }
+})

--- a/tests/testthat/test-return.R
+++ b/tests/testthat/test-return.R
@@ -1,0 +1,35 @@
+test_that("Exported code has @return", {
+  pkg_dir <- stringr::str_remove(getwd(), "/tests/testthat")
+
+  r_files  <- list.files(path = file.path(pkg_dir, "R"),   pattern = r"{\.[Rr]$}",     full.names = TRUE)
+
+  files_to_check <- r_files
+
+  for (file in files_to_check) {
+    lines <- readLines(file, warn = FALSE)
+
+    code_blocks <- lines |>
+      stringr::str_detect("^#'") |>
+      (\(.) . & !c(FALSE, .[-length(.)]))() |>
+      cumsum() |>
+      (\(.) split(lines, .))()
+
+    # Truncate
+    code_blocks <- purrr::map(code_blocks, ~ purrr::discard(., cumprod(stringr::str_detect(., "^$")) == 1))
+
+    # Look for @export tag
+    exported_code_blocks <- purrr::keep(code_blocks, ~ any(stringr::str_detect(., "@export")))
+
+    # Look for missing @return tag
+    no_return <- purrr::discard(exported_code_blocks, ~ any(stringr::str_detect(., "@return")))
+
+    # Report issues
+    for (block in no_return) {
+      function_with_issue <- purrr::keep(block, ~ stringr::str_detect(., r"{(?<= <-) (function\(|R6::R6Class)}")) |>
+        stringr::str_extract(r"{^[\w\.%`]*(?= <-)}")
+
+      expect_true(any(stringr::str_detect(block, "@return")),
+                  label = glue::glue("{function_with_issue} is exported but has no @return"))
+    }
+  }
+})


### PR DESCRIPTION
This PR adds the test workflows that checks the three following things
1) All .Rd files have \examples
2) All .Rd files have \value
3) Files do not contain non-ascii symbols

fixes #10 