### PR TITLE
Add GitHub workflows and templates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^\.github$
 .lintr
 ^cran-comments\.md$
+^README\.Rmd$

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Provide output from `sessionInfo()`**
+```r
+# paste output within this block for formatting
+```
+
+* [ ] I have checked that the bug is not already described in [open issues](https://github.com/ssi-dk/SCDB/issues?q=is%3Aopen)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!-- Thanks for contributing!
+
+Before creating your pull request, please read this comment in its entirety.
+This will help with reviewing the changes and hopefully merge your changes into
+the repository as smoothly as possible.
+
+
+# Pull request title
+
+Your title should be short yet exhaustive. Hopefully, this comes easily,
+as pull requests should be single-topic as possible.
+
+
+# Issue references
+Ideally, the PR addresses an issue. If so, please reference the issue number
+in the PR title and/or the body text. See also "Linking a pull request to an issue"
+linked in the "Intent" section.
+
+
+# Automated tests
+The package supports several backends, and tests the coverage of these.
+If the pull request modifies code which is used by multiple backends, please
+test the changes locally before submitting a pull request if possible.
+-->
+
+### Intent
+
+> Describe briefly what problem the pull request resolves, or new features it
+> introduces.
+> Please link to issues if possible
+> (see also ["Linking a pull request to an issue"](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)).
+>
+> Trivial changes, like fixing a typo, does not need an issue. 
+
+
+### Approach
+
+> How was the issue resolved?
+> Describe the approach taken; describe any non-obvious considerations made in
+> choosing this approach.
+>
+> If the change cannot or will not be covered by a test, please explain why.
+
+
+### Known issues
+> If any known issues are introduced by this pull request, please let us know.
+> Code is rarely perfect, and a pull request is still welcome if the fix is
+> bigger than the new bug.
+
+
+### Checklist
+
+* [ ] The PR passes all local unit tests
+* [ ] I have documented any new features introduced
+* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
+* [ ] A reviewer is assigned to this PR

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,42 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["R/**"]
+
+name: Document
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: roxygen2
+
+      - name: Document
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add man/\* NAMESPACE DESCRIPTION
+          git commit -m "Update documentation" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/.github/workflows/r-license-report.yaml
+++ b/.github/workflows/r-license-report.yaml
@@ -1,0 +1,19 @@
+# Workflow frrom https://github.com/marketplace/actions/r-dependency-license-report
+
+---
+name: License Report
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  license-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: License Report
+        uses: insightsengineering/r-license-report@v1

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    paths:
+      - README.md
+      - README.Rmd
+
+name: Render README
+
+jobs:
+  render:
+    name: Render README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Install rmarkdown
+        run: Rscript -e 'install.packages("rmarkdown")'
+      - name: Render README
+        run: Rscript -e 'rmarkdown::render("README.Rmd")'
+      - name: Commit results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,52 @@
+---
+output:
+  - github_document
+  - md_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file. -->
+
+```{r, echo = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-"
+)
+```
+
+# diseasy <a href="https://ssi-dk.github.io/diseasy/"><img src="man/figures/logo.png" align="right" height="138" alt="diseasy website" /></a>
+
+<!-- badges: start -->
+
+[![CRAN status](https://www.r-pkg.org/badges/version/diseasy)](https://CRAN.R-project.org/package=diseasy)
+[![R-CMD-check](https://github.com/ssi-dk/diseasy/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ssi-dk/diseasy/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/ssi-dk/diseasy/graph/badge.svg?token=7RRVVVHOWR)](https://codecov.io/gh/ssi-dk/diseasy)
+
+
+<!-- badges: end -->
+
+## Overview
+Leveraging combinatorial building for ensemble forecasting in disease modelling
+
+## The power of combinations
+`diseasy` is framework for disease modelling that is built around the philosophy of combinatorial building.
+Even from a small number of modules, an ensemble consisting of a vast array of disease models can be constructed by combining individual modules.
+
+## The power of ensembles
+Ensemble models of disease spread typically outperforms individual models in terms of robust and accurate forecasts.
+With `diseasy`, ensemble models are leveraged to support evidence-based decision-making and pandemic preparedness.
+
+## Installation
+
+```{r, eval = FALSE}
+# Install diseasy from CRAN:
+install.packages("diseasy")
+
+# Alternatively, install the development version from github:
+# install.packages("devtools")
+devtools::install_github("ssi-dk/diseasy")
+```
+
+## Usage
+
+For basic usage examples, see `vignette("basic_principles")`.


### PR DESCRIPTION
This PR adds a couple of workflows to the repo.
1) A workflow to render README from RMarkdown 
2) A template for pull requests and bug reports
3) A workflow for upstream licenses
4) A workflow to document the package (pkgdown)