### PR TITLE
Revert "chore: vroom_() workaround: compile RSQLite from source"

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, github::ssi-dk/diseasystore, github::r-dbi/RSQLite
+          extra-packages: any::rcmdcheck, github::ssi-dk/diseasystore
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -52,7 +52,6 @@ jobs:
             any::knitr
             any::rmarkdown
             github::ssi-dk/diseasystore
-            github::r-dbi/RSQLite
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, github::ssi-dk/diseasystore, github::r-dbi/RSQLite
+          extra-packages: any::covr, github::ssi-dk/diseasystore
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
Reverts ssi-dk/diseasy#50

PR #50 was a temporary measure while an issue with `vroom` and `RSQLite` exists.
This PR reverts that temporary measure