### PR TITLE
feat(DiseasyActivity): ensure consistent age_groups in data

### DIFF
--- a/R/DiseasyActivity.R
+++ b/R/DiseasyActivity.R
@@ -81,7 +81,7 @@ DiseasyActivity <- R6::R6Class( # nolint: object_name_linter
       checkmate::assert_number(n_age_groups, add = coll)
 
       # - Compare number of age groups with currently loaded data
-      # activity_units may contain only scalar information with out issues.
+      # activity_units may contain only scalar information without issues.
       # If it does, we don't need to match the number of age groups
       if (!is.null(private$n_age_groups) && n_age_groups > 1) {
         checkmate::assert_true(n_age_groups == private$n_age_groups, add = coll)

--- a/R/DiseasyActivity.R
+++ b/R/DiseasyActivity.R
@@ -89,7 +89,7 @@ DiseasyActivity <- R6::R6Class( # nolint: object_name_linter
 
       checkmate::reportAssertions(coll)
 
-      # Add to module
+      # Store the number of age groups
       if (is.null(private$n_age_groups) && n_age_groups > 1) private$n_age_groups <- n_age_groups
       private$activity_units        <- activity_units
       private$activity_units_labels <- names(activity_units)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR adds checks that `activity_units` and `contact_basis` uses the same number of age groups

### Approach
When evoking either `$set_activity_units()` or `$set_contact_basis()` the function will now do the following:
1) Check if that the explicit or implicit `age_groups` of the `activity_units` / `contact_basis` are consistent across the input
2) Check that the number of `age_groups` of the input is consistent with data that is already loaded into the module
    If not, a `checkmate::` assertion will throw an error

Note that `activity_units` can consist solely of scalar values which will look like just 1 age group.
Therefore, `$set_activity_units()` will only store the number of age groups if the `activity_units` explicitly has more than 1 age group.

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
