### PR TITLE
Adjust workflow triggering with PR detection

### DIFF
--- a/.github/workflows/all-workflows.yaml
+++ b/.github/workflows/all-workflows.yaml
@@ -1,15 +1,13 @@
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
-  release:
-  workflow_dispatch:
+on: [push, pull_request, release, workflow_dispatch]
 
 name: CI tests
 jobs:
 
   # We call the reusable workflow that triggers all AEF-DDF workflows
   run-all-AEF-DFF-workflows:
+    concurrency:
+      group: all_workflows
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     name: ⚙️ Dispatch
     uses: ssi-dk/AEF-DDF/.github/workflows/workflow-dispatcher.yaml@workflows
     with:

--- a/.github/workflows/all-workflows.yaml
+++ b/.github/workflows/all-workflows.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request, release, workflow_dispatch]
 name: CI tests
 jobs:
 
-  detect-pr:
+  context:
     name: ⚙️ Context
     runs-on: ubuntu-latest
     env:
@@ -24,8 +24,8 @@ jobs:
   # We call the reusable workflow that triggers all AEF-DDF workflows
   run-all-AEF-DFF-workflows:
     name: ⚙️ Dispatch
-    needs: detect-pr
-    if: needs.pr_detect.outputs.abort != 'true'
+    needs: context
+    if: needs.context.outputs.abort != 'true'
     uses: ssi-dk/AEF-DDF/.github/workflows/workflow-dispatcher.yaml@workflows
     with:
       # We pass information about the triggering event

--- a/.github/workflows/all-workflows.yaml
+++ b/.github/workflows/all-workflows.yaml
@@ -3,12 +3,29 @@ on: [push, pull_request, release, workflow_dispatch]
 name: CI tests
 jobs:
 
+  detect-pr:
+    name: ⚙️ Context
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      abort: ${{ steps.pr_detect.outputs.abort }}
+    steps:
+      - name: Detect PR on current branch
+        if: github.event_name == 'push'
+        id: pr_detect
+        run: |
+          pr_branches=$(gh pr list --json headRefName --repo $GITHUB_REPOSITORY)
+          if [[ $(echo "$pr_branches" | jq -r --arg GITHUB_REF '.[].headRefName | select(. == $GITHUB_REF)') ]]; then
+            echo "This push is associated with a pull request. Skipping the job."
+            echo "abort=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # We call the reusable workflow that triggers all AEF-DDF workflows
   run-all-AEF-DFF-workflows:
-    concurrency:
-      group: all_workflows
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     name: ⚙️ Dispatch
+    needs: detect-pr
+    if: needs.pr_detect.outputs.abort != 'true'
     uses: ssi-dk/AEF-DDF/.github/workflows/workflow-dispatcher.yaml@workflows
     with:
       # We pass information about the triggering event


### PR DESCRIPTION
Github events "push" and "pull_request" both still trigger workflows during PR. This PR intends to prevent this double triggering.