### PR TITLE
Disable test across all diseasystores

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -7,7 +7,13 @@ installed.packages()[, 1] |>
   purrr::walk(~ eval(parse(text = glue::glue("library({.})")))) # Thanks R, for being so difficult.
 
 # Determine the available diseasystore to test over
-case_defs <- diseasystore::available_diseasystores() |> stringr::str_remove_all(stringr::fixed("Diseasystore"))
+# NOTE: More diseasystores are available, but we need new features on diseasystore to dynamically test these in diseasy
+# Specifically, we need to be able to query the min and max dates where data is available in the diseasystore.
+# https://github.com/ssi-dk/diseasystore/issues/135
+# And we need to dynamically be able to discriminate between observables and stratifications:
+# https://github.com/ssi-dk/diseasystore/issues/89
+# Once these features are added, we should be able to adapt the tests to test over all available diseasystores.
+case_defs <- "GoogleCovid19"
 
 # Create a connection to test on
 tmp_dir <- stringr::str_replace_all(tempdir(), stringr::fixed(r"{\\}"), .Platform$file.sep)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
Since the release of `diseasystore` v0.2, the tests for `diseasy` have been failing.
These failing tests are due to the addition of `DiseasystoreEcdcRespiratoryViruses`.

The tests for `DiseasyObservables` uses all available diseasystores for testing, but uses a hard-coded set of dates and observable names which is only compatible with `DiseasystoreGoogleCovid19`.

This PR fixes the currently failing tests by only testing `DiseasyObservables` on `DiseasystoreGoogleCovid19`.

This is a stop-gap measure until more functionality is added to `diseasystore` so that we can dynamically test across all available diseasystores.
The issue is tracked here: https://github.com/ssi-dk/diseasy/issues/98



### Approach
Instead of dynamically determining the diseasystores to test over, the tests are hard-coded to use `DiseasystoreGoogleCovid19`

### Known issues
The test are still failing (with warnings, not errors) due to a waning about deprecated `check_from` argument in `dbplyr`.
This will be fixed with the next release of diseasystore: 
* [x] https://github.com/ssi-dk/diseasystore/pull/134

The R-CMD-Check without dependencies is failing.
This is being fixed in a different PR
* [ ] https://github.com/ssi-dk/diseasy/pull/102

### Checklist

* [ ] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
