### PR TITLE
fix(DiseasysBaseModule): Finalise hidden objects

### DIFF
--- a/R/DiseasyBaseModule.R
+++ b/R/DiseasyBaseModule.R
@@ -131,7 +131,7 @@ DiseasyBaseModule <- R6::R6Class(                                               
     finalize = function() {
       # Look for contained Diseasy* classes and call finalize on these
       private |>
-        as.list() |>
+        as.list(all.names = TRUE) |>
         purrr::keep(~ inherits(., "DiseasyBaseModule")) |>
         purrr::discard(~ isTRUE(attr(., "clone"))) |>
         purrr::walk(~ .$finalize())

--- a/R/DiseasyObservables.R
+++ b/R/DiseasyObservables.R
@@ -249,9 +249,8 @@ DiseasyObservables <- R6::R6Class(                                              
     #' @description
     #'   Handles the clean-up of the class
     finalize = function() {
-
       # Close the connection, then do rest of clean-up
-      if (DBI::dbIsValid(self$conn)) DBI::dbDisconnect(self$conn)
+      if (!isTRUE(attr(self, "clone")) && DBI::dbIsValid(self$conn)) DBI::dbDisconnect(self$conn)
       super$finalize()
     }
   ),


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent

This PR aims to fix an issue with the `$finalize()` method where connections in `DiseasyObservables` was closed even though it may still be needed. This is due to an misidentification of when the module is a clone and when it is not.

Currently:
``` r
library(diseasy)
#> Loading required package: diseasystore
#> 
#> Attaching package: 'diseasy'
#> The following object is masked from 'package:diseasystore':
#> 
#>     diseasyoption

# Create observables module and load into new model module
conn <- DBI::dbConnect(RSQLite::SQLite())
obs <- DiseasyObservables$new(conn = conn)
m <- DiseasyModel$new(obs = obs)

# Connection is open
DBI::dbIsValid(conn)
#> [1] TRUE

rm(m)
gc()
#>           used  (Mb) gc trigger  (Mb) max used  (Mb)
#> Ncells 2245515 120.0    4423050 236.3  3060657 163.5
#> Vcells 3895580  29.8    8388608  64.0  6310127  48.2

# Connection is closed even though "obs" was not deleted
DBI::dbIsValid(conn)
#> [1] FALSE
```

<sup>Created on 2024-11-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


After the changes:
``` r
library(diseasy)
#> Loading required package: diseasystore
#> 
#> Attaching package: 'diseasy'
#> The following object is masked from 'package:diseasystore':
#> 
#>     diseasyoption

# Create observables module and load into new model module
conn <- DBI::dbConnect(RSQLite::SQLite())
obs <- DiseasyObservables$new(conn = conn)
m <- DiseasyModel$new(obs = obs)

# Connection is open
DBI::dbIsValid(conn)
#> [1] TRUE

rm(m)
gc()
#>           used  (Mb) gc trigger  (Mb) max used  (Mb)
#> Ncells 2245584 120.0    4424724 236.4  3057711 163.3
#> Vcells 3894870  29.8    8388608  64.0  6310292  48.2

# Connection is still open
DBI::dbIsValid(conn)
#> [1] TRUE

rm(obs)
gc()
#>           used  (Mb) gc trigger  (Mb) max used  (Mb)
#> Ncells 2245185 120.0    4424724 236.4  3057711 163.3
#> Vcells 3895349  29.8    8388608  64.0  6310292  48.2

# We have to remove the original for the connection to be closed
DBI::dbIsValid(conn)
#> [1] FALSE
```

<sup>Created on 2024-11-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


### Approach
The `$finalise()` method of `DiseasyObservables` was updated to check for the "clone" attribute

The `$finalise()` method of `DiseasyModel` was updated to call finalise on all objects (including hidden)

### Known issues
N/A


### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
