### PR TITLE
Update the minimum supported R version

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^data-raw$
 .vscode
 ^pak.lock
+^pkg-build$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Language: en-GB
 LazyData: TRUE
 Depends:
     diseasystore (>= 0.3),
-    R (>= 3.5.0)
+    R (>= 4.3.0)
 Imports:
     cachem,
     checkmate,

--- a/R/DiseasyObservables.R
+++ b/R/DiseasyObservables.R
@@ -87,7 +87,7 @@ DiseasyObservables <- R6::R6Class(                                              
     #'   Must match case definition implemented in `diseasystore` package.
     #' @param verbose (`logical`)\cr
     #'   Should the `diseasystore` use verbose outputs?
-    #' @seealso [diseasystore]
+    #' @seealso [diseasystore::diseasystore]
     set_diseasystore = function(diseasystore, verbose = NULL) {
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_character(diseasystore, add = coll)

--- a/man/DiseasyObservables.Rd
+++ b/man/DiseasyObservables.Rd
@@ -37,7 +37,7 @@ See vignette("diseasy-observables")
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\link{diseasystore}
+\link[diseasystore:diseasystore-package]{diseasystore::diseasystore}
 
 \link[SCDB:get_table]{SCDB::get_table}
 

--- a/pak.lock
+++ b/pak.lock
@@ -2240,7 +2240,7 @@
     {
       "ref": "openssl",
       "package": "openssl",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -2252,10 +2252,10 @@
         "RemoteRef": "openssl",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "2.2.2"
+        "RemoteSha": "2.3.0"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/openssl_2.2.2.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/openssl_2.2.2.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/openssl_2.3.0.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/openssl_2.3.0.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -2278,7 +2278,7 @@
     {
       "ref": "parallelly",
       "package": "parallelly",
-      "version": "1.40.1",
+      "version": "1.41.0",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -2290,10 +2290,10 @@
         "RemoteRef": "parallelly",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.40.1"
+        "RemoteSha": "1.41.0"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/parallelly_1.40.1.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/parallelly_1.40.1.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/parallelly_1.41.0.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/parallelly_1.41.0.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -2309,11 +2309,11 @@
     {
       "ref": "pillar",
       "package": "pillar",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "type": "standard",
       "direct": false,
       "binary": true,
-      "dependencies": ["cli", "fansi", "glue", "lifecycle", "rlang", "utf8", "vctrs"],
+      "dependencies": ["cli", "glue", "lifecycle", "rlang", "utf8", "vctrs"],
       "vignettes": false,
       "metadata": {
         "RemotePkgRef": "pillar",
@@ -2321,10 +2321,10 @@
         "RemoteRef": "pillar",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.9.0"
+        "RemoteSha": "1.10.0"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/pillar_1.9.0.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/pillar_1.9.0.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/pillar_1.10.0.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/pillar_1.10.0.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,

--- a/tests/testthat/test-DiseasyActivity.R
+++ b/tests/testthat/test-DiseasyActivity.R
@@ -231,7 +231,11 @@ test_that("$get_scenario_openness() works", {
   act$set_activity_units(dk_activity_units_subset)
 
   # With no scenario, we should get a empty list
-  expect_identical(act$get_scenario_openness(), stats::setNames(list(), character(0)))
+  if (paste(R.version$major, R.version$minor, sep = ".") < "4.4.0") {
+    expect_identical(act$get_scenario_openness(), list())
+  } else {
+    expect_identical(act$get_scenario_openness(), stats::setNames(list(), character(0)))
+  }
 
   # Now we load a scenario
   act$change_activity(date = as.Date(c("2020-01-01", "2020-03-12",    "2020-04-15")),


### PR DESCRIPTION
The minimum supported R version has not been tested in CI until recently and this has hidden missing compatibility with older versions of R.

This PR updates the minimum supported R version and ensures compatibility with the version.

Since `diseasy` and `diseasystore` are trying to do state-of-the-art modelling, we will not support older versions of R which does not offer sufficient programming features.

### Approach
- DESCRIPTION updated to set the minimum version of R

### Known issues
N/A


### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR