### PR TITLE
`DiseasyPopulation`: Integrate `DiseasyRegions`

### DIFF
--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -208,6 +208,19 @@ rd_activity_weights <- paste(
   "vector of weights for the four types of contacts. If `NULL`, no weighting is done."
 )
 
+
+## Templates for DiseasyPopulation
+rd_regional_stratification <- function(type = "param") {
+  checkmate::assert_choice(type, c("param", "field"))
+  paste(
+    "(`character()`)\\cr",
+    "The level of spatial stratification of the population.",
+    switch(type == "field", "Read only.")
+  )
+}
+
+
+
 ## Templates for DiseasyRegions
 rd_regions <- function(type = "param") {
   checkmate::assert_choice(type, c("param", "field"))

--- a/R/DiseasyActivity.R
+++ b/R/DiseasyActivity.R
@@ -633,12 +633,11 @@ DiseasyActivity <- R6::R6Class(                                                 
     },
 
 
-                                                                                                                        # nolint start: documentation_template_linter, identation_linter
     #' Map population between age groups
     #'
     #' @description
     #'   The function computes the proportion of population in the new and old age groups.
-    #' @param age_cuts_lower_out `r rd_age_cuts_lower()`
+    #' @param age_cuts_lower `r rd_age_cuts_lower()`
     #' @param age_groups_reference (`character()`)\cr
     #'   Age labels (created by `diseasystore::age_labels()` of reference data.
     #' @param demography (`data.frame`)\cr
@@ -650,14 +649,14 @@ DiseasyActivity <- R6::R6Class(                                                 
     #'   A `data.frame` which maps the age groups from their reference in `contact_basis` to
     #'   those supplied to the function.
     map_population = function(                                                                                          # nolint end: documentation_template_linter, identation_linter
-      age_cuts_lower_out,
+      age_cuts_lower,
       age_groups_reference = names(self$contact_basis$proportion),
       demography = self$contact_basis$demography
     ) {
 
       # Input checks
       coll <- checkmate::makeAssertCollection()
-      checkmate::assert_numeric(age_cuts_lower_out, any.missing = FALSE, null.ok = TRUE,
+      checkmate::assert_numeric(age_cuts_lower, any.missing = FALSE, null.ok = TRUE,
                                 lower = 0, unique = TRUE, add = coll)
       checkmate::assert_character(age_groups_reference, add = coll)
       checkmate::reportAssertions(coll)
@@ -670,7 +669,7 @@ DiseasyActivity <- R6::R6Class(                                                 
       population <- data.frame(age = 0:(length(proportion) - 1), proportion = proportion)
 
       population$age_group_ref <- sapply(population$age, \(x) sum(x >= lower_ref))
-      population$age_group_out <- sapply(population$age, \(x) sum(x >= age_cuts_lower_out))
+      population$age_group_out <- sapply(population$age, \(x) sum(x >= age_cuts_lower))
 
       return(population)
     },

--- a/R/DiseasyActivity.R
+++ b/R/DiseasyActivity.R
@@ -637,28 +637,38 @@ DiseasyActivity <- R6::R6Class(                                                 
     #'
     #' @description
     #'   The function computes the proportion of population in the new and old age groups.
-    #' @param age_cuts_lower `r rd_age_cuts_lower()`
+    #' @param age_cuts_lower_out `r rd_age_cuts_lower()`
+    #' @param age_groups_reference (`character()`)\cr
+    #'   Age labels (created by `diseasystore::age_labels()` of reference data.
+    #' @param demography (`data.frame`)\cr
+    #'   "A `data.frame` with the columns\\cr",
+    #'   "  * `age` (`integer()`) 1-year age group\\cr",
+    #'   "  * `population` (`numeric()`) size of population in age group\\cr",
+    #'   "  * `proportion` (`numeric()`) proportion of total population in age group\\cr",
     #' @return
     #'   A `data.frame` which maps the age groups from their reference in `contact_basis` to
     #'   those supplied to the function.
-    map_population = function(age_cuts_lower) {
+    map_population = function(
+      age_cuts_lower_out,
+      age_groups_reference = names(self$contact_basis$proportion),
+      demography = self$contact_basis$demography) {
 
       # Input checks
       coll <- checkmate::makeAssertCollection()
-      checkmate::assert_numeric(age_cuts_lower, any.missing = FALSE, null.ok = TRUE,
+      checkmate::assert_numeric(age_cuts_lower_out, any.missing = FALSE, null.ok = TRUE,
                                 lower = 0, unique = TRUE, add = coll)
-      checkmate::assert_character(names(self$contact_basis$proportion), add = coll)
+      checkmate::assert_character(age_groups_reference, add = coll)
       checkmate::reportAssertions(coll)
 
       # Using default population from contact_basis
-      proportion <- self$contact_basis$demography$proportion
+      proportion <- demography$proportion
 
       # Creating mapping for all ages to reference and provided age_groups
-      lower_ref <- as.integer(sapply(strsplit(x = names(self$contact_basis$proportion), split = "[-+]"), \(x) x[1]))
+      lower_ref <- as.integer(sapply(strsplit(x = age_groups_reference, split = "[-+]"), \(x) x[1]))
       population <- data.frame(age = 0:(length(proportion) - 1), proportion = proportion)
 
       population$age_group_ref <- sapply(population$age, \(x) sum(x >= lower_ref))
-      population$age_group_out <- sapply(population$age, \(x) sum(x >= age_cuts_lower))
+      population$age_group_out <- sapply(population$age, \(x) sum(x >= age_cuts_lower_out))
 
       return(population)
     },

--- a/R/DiseasyActivity.R
+++ b/R/DiseasyActivity.R
@@ -633,6 +633,7 @@ DiseasyActivity <- R6::R6Class(                                                 
     },
 
 
+                                                                                                                        # nolint start: documentation_template_linter, identation_linter
     #' Map population between age groups
     #'
     #' @description
@@ -648,10 +649,11 @@ DiseasyActivity <- R6::R6Class(                                                 
     #' @return
     #'   A `data.frame` which maps the age groups from their reference in `contact_basis` to
     #'   those supplied to the function.
-    map_population = function(
+    map_population = function(                                                                                          # nolint end: documentation_template_linter, identation_linter
       age_cuts_lower_out,
       age_groups_reference = names(self$contact_basis$proportion),
-      demography = self$contact_basis$demography) {
+      demography = self$contact_basis$demography
+    ) {
 
       # Input checks
       coll <- checkmate::makeAssertCollection()

--- a/R/DiseasyModel.R
+++ b/R/DiseasyModel.R
@@ -7,10 +7,13 @@
 #'   Most notably, the model module facilitates:
 #'   * Module interfaces:
 #'     The module contains the functional modules via its active bindings:
-#'     * `$activity`: `DiseasyActivity`
 #'     * `$observables`: `DiseasyObservables`
+#'     * `$population` : `DiseasyPopulation`
+#'     * `$activity`: `DiseasyActivity`
+#'     * `$region`: `DiseasyRegions`
 #'     * `$season`: `DiseasySeason`
 #'     * `$variant` : `DiseasyVariant`
+#'     * `$immunity` : `DiseasyImmunity`
 #'
 #'     Configured instances of these modules can be provided during initialisation.
 #'     Alternatively, default instances of these modules can optionally be created.
@@ -37,7 +40,7 @@ DiseasyModel <- R6::R6Class(                                                    
     #' @description
     #'   Creates a new instance of the `DiseasyModel` [R6][R6::R6Class] class.
     #'   This module is typically not constructed directly but rather through `DiseasyModel*` classes.
-    #' @param observables,population,activity,season,variant,immunity `r rd_diseasy_module`
+    #' @param observables,population,activity,region,season,variant,immunity `r rd_diseasy_module`
     #' @param parameters (`named list()`)\cr
     #'   List of parameters to set for the model during initialization.
     #'
@@ -59,6 +62,7 @@ DiseasyModel <- R6::R6Class(                                                    
       observables = FALSE,
       population  = FALSE,
       activity    = FALSE,
+      region      = FALSE,
       season      = FALSE,
       variant     = FALSE,
       immunity    = FALSE,
@@ -81,6 +85,11 @@ DiseasyModel <- R6::R6Class(                                                    
       checkmate::assert(
         checkmate::check_logical(activity, null.ok = TRUE),
         checkmate::check_class(activity, "DiseasyActivity", null.ok = TRUE),
+        add = coll
+      )
+      checkmate::assert(
+        checkmate::check_logical(region, null.ok = TRUE),
+        checkmate::check_class(region, "DiseasyRegions", null.ok = TRUE),
         add = coll
       )
       checkmate::assert(
@@ -130,6 +139,12 @@ DiseasyModel <- R6::R6Class(                                                    
         self$load_module(DiseasyActivity$new())
       } else if (inherits(activity, "DiseasyActivity")) {
         self$load_module(activity)
+      }
+
+      if (isTRUE(region)) {
+        self$load_module(DiseasyRegions$new())
+      } else if (inherits(region, "DiseasyRegions")) {
+        self$load_module(region)
       }
 
       if (isTRUE(season)) {
@@ -254,6 +269,17 @@ DiseasyModel <- R6::R6Class(                                                    
   # Make active bindings to the private variables
   active  = list(
 
+    #' @field observables (`diseasy::DiseasyObservables`)\cr
+    #'   The local copy of a DiseasyObservables module. Read-only.
+    #' @seealso [diseasy::DiseasyObservables]
+    #' @importFrom diseasystore `%.%`
+    observables = purrr::partial(
+      .f = active_binding,
+      name = "observables",
+      expr = return(private %.% .DiseasyObservables)
+    ),
+
+
     #' @field population (`diseasy::DiseasyPopulation`)\cr
     #'   The local copy of a DiseasyPopulation module. Read-only.
     #' @seealso [diseasy::DiseasyPopulation]
@@ -276,25 +302,14 @@ DiseasyModel <- R6::R6Class(                                                    
     ),
 
 
-    #' @field immunity (`diseasy::DiseasyImmunity`)\cr
-    #'   The local copy of a DiseasyImmunity module. Read-only.
-    #' @seealso [diseasy::DiseasyImmunity]
+    #' @field region (`diseasy::DiseasyRegions`)\cr
+    #'   The local copy of an DiseasyRegions module. Read-only.
+    #' @seealso [diseasy::DiseasyRegions]
     #' @importFrom diseasystore `%.%`
-    immunity = purrr::partial(
+    region = purrr::partial(
       .f = active_binding,
-      name = "Immunity",
-      expr = return(private %.% .DiseasyImmunity)
-    ),
-
-
-    #' @field observables (`diseasy::DiseasyObservables`)\cr
-    #'   The local copy of a DiseasyObservables module. Read-only.
-    #' @seealso [diseasy::DiseasyObservables]
-    #' @importFrom diseasystore `%.%`
-    observables = purrr::partial(
-      .f = active_binding,
-      name = "observables",
-      expr = return(private %.% .DiseasyObservables)
+      name = "region",
+      expr = return(private %.% .DiseasyRegions)
     ),
 
 
@@ -317,6 +332,17 @@ DiseasyModel <- R6::R6Class(                                                    
       .f = active_binding,
       name = "variant",
       expr = return(private %.% .DiseasyVariant)
+    ),
+
+
+    #' @field immunity (`diseasy::DiseasyImmunity`)\cr
+    #'   The local copy of a DiseasyImmunity module. Read-only.
+    #' @seealso [diseasy::DiseasyImmunity]
+    #' @importFrom diseasystore `%.%`
+    immunity = purrr::partial(
+      .f = active_binding,
+      name = "Immunity",
+      expr = return(private %.% .DiseasyImmunity)
     ),
 
 
@@ -444,12 +470,13 @@ DiseasyModel <- R6::R6Class(                                                    
 
   private = list(
 
+    .DiseasyObservables = NULL,
     .DiseasyPopulation  = NULL,
     .DiseasyActivity    = NULL,
-    .DiseasyImmunity    = NULL,
-    .DiseasyObservables = NULL,
+    .DiseasyRegions     = NULL,
     .DiseasySeason      = NULL,
     .DiseasyVariant     = NULL,
+    .DiseasyImmunity    = NULL,
     .parameters = NULL,
 
     # @field default_parameters (`list`)\cr

--- a/R/DiseasyModelOde.R
+++ b/R/DiseasyModelOde.R
@@ -432,9 +432,13 @@ DiseasyModelOde <- R6::R6Class(                                                 
         variant_stratification <- rlang::quos(variant)
       }
 
-      ## Age group
+      ## Age group stratification
       # If age groups are defined in the model, check it is supported by the data
-      if (length(self %.% population %.% age_cuts_lower) > 1) {
+      if (length(self %.% population %.% age_cuts_lower) == 0) {
+
+        age_group_stratification <- rlang::quos(age_group = "0+") # No age groups in the model
+
+      } else { # Age groups in the model
 
         # Can we map from the age groups in the data to the age groups in the model?
         # We use `checkmate::test_choice` because `%in%` randomly does not work in this case.
@@ -494,18 +498,28 @@ DiseasyModelOde <- R6::R6Class(                                                 
             parse(text = paste0(" rlang::quos(age_group = dplyr::case_match(", age_groups_maps, "))"))
           )
         }
-
-      } else {
-        # No age groups in the model
-        age_group_stratification <- rlang::quos(age_group = "0+")
       }
 
+      ## Regional stratification
+      # If regions are defined in the model, check it is supported by the data
+      if (is.null(self %.% population %.% regional_stratification)) {
 
+        # No age groups in the model
+        regional_stratification <- rlang::quos(region = "All")
+
+      } else {
+
+        # Can we map from the regions in the data to the regions in the model?
+        if (checkmate::test_choice("region", self %.% observables %.% available_stratifications)) {
+          # TODO
+        }
+      }
 
       # Set the stratification to the highest level supported by the data / model
       model_stratification <- c(
         variant_stratification,
-        age_group_stratification
+        age_group_stratification,
+        regional_stratification
       )
 
       return(model_stratification)

--- a/R/DiseasyModelOde.R
+++ b/R/DiseasyModelOde.R
@@ -375,7 +375,12 @@ DiseasyModelOde <- R6::R6Class(                                                 
         colnames(sol) <- c(
           "time",
           psi |>
-            tidyr::unite("label", "variant", "age_group", "state", sep = "/", na.rm = FALSE) |>
+            tidyr::unite(
+              "label",
+              dplyr::all_of(c("variant", colnames(self %.% population %.% groups), "state")),
+              sep = "/",
+              na.rm = FALSE
+            ) |>
             dplyr::pull("label")
         )
 

--- a/R/DiseasyModelOdeSeir.R
+++ b/R/DiseasyModelOdeSeir.R
@@ -168,6 +168,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       checkmate::assert_class(self %.% observables, "DiseasyObservables")
       checkmate::assert_date(self %.% observables %.% last_queryable_date, add = coll)
       checkmate::assert_class(self %.% activity, "DiseasyActivity", add = coll)
+      checkmate::assert_class(self %.% region, "DiseasyRegions", add = coll)
       checkmate::assert_class(self %.% season, "DiseasySeason", add = coll)
       checkmate::assert_class(self %.% variant, "DiseasyVariant", add = coll)
       checkmate::assert_class(self %.% immunity, "DiseasyImmunity", add = coll)

--- a/R/DiseasyModelOdeSeir.R
+++ b/R/DiseasyModelOdeSeir.R
@@ -819,7 +819,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
           dplyr::all_of(
             c("variant", colnames(self %.% population %.% groups),  "state")
           )
-        )
+        ) |>
         dplyr::union_all(
           dplyr::mutate(
             self %.% population %.% groups,

--- a/R/DiseasyModelOdeSeir.R
+++ b/R/DiseasyModelOdeSeir.R
@@ -76,7 +76,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
 
     #' @description
     #'   Creates a new instance of the `DiseasyModelOdeSeir` [R6][R6::R6Class] class.
-    #' @param observables,population,activity,season,variant,immunity `r rd_diseasy_module`
+    #' @param observables,population,activity,region,season,variant,immunity `r rd_diseasy_module`
     #' @param parameters (`named list()`)\cr
     #'   List of parameters to set for the model during initialization.
     #'
@@ -116,6 +116,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       observables = FALSE,
       population = TRUE,
       activity = TRUE,
+      region = TRUE,
       season = TRUE,
       variant = TRUE,
       immunity = TRUE,
@@ -128,6 +129,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
         observables = observables,
         population = population,
         activity = activity,
+        region = region,
         season = season,
         variant = variant,
         immunity = immunity,

--- a/R/DiseasyModelOdeSeir.R
+++ b/R/DiseasyModelOdeSeir.R
@@ -450,7 +450,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       checkmate::assert_data_frame(incidence_data, add = coll)
       checkmate::assert_names(
         colnames(incidence_data),
-        must.include = c("date", "incidence", names(self %.% population %.% groups)),
+        must.include = c("date", "incidence", colnames(self %.% population %.% groups)),
         add = coll
       )
 
@@ -465,7 +465,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
 
       # Check demography columns
       # (Input data must include the stratifications in the model)
-      for (group in names(self %.% population %.% groups)) {
+      for (group in colnames(self %.% population %.% groups)) {
         checkmate::assert_set_equal(
           dplyr::pull(incidence_data, group),
           self %.% population %.% groups[[group]],
@@ -504,7 +504,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       incidence_data <- incidence_data |>
         dplyr::left_join(
           self %.% population %.% population,
-          by = names(self %.% population %.% groups)
+          by = colnames(self %.% population %.% groups)
         ) |>
         dplyr::mutate("incidence" = .data$incidence * .data$proportion) |>
         dplyr::select(c(colnames(incidence_data), "incidence"))
@@ -520,7 +520,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
 
       if (nrow(missing_data) > 0) {
         groups_w_missing_data <- missing_data |>
-          dplyr::select(c(names(self %.% population %.% groups), "variant")) |>
+          dplyr::select(c(colnames(self %.% population %.% groups), "variant")) |>
           dplyr::distinct() |>
           dplyr::rowwise() |>
           dplyr::group_map(~ unlist(as.vector(.x[1, ]))) |>
@@ -543,8 +543,8 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       # and extract the subsets.
       # We also need to ensure the variants are ordered as the state vector is
       incidence_subsets <- incidence_data |>
-        dplyr::arrange(dplyr::across(.cols = c("variant", names(self %.% population %.% groups)))) |>
-        dplyr::group_by(dplyr::across(.cols = c("variant", names(self %.% population %.% groups)))) |>
+        dplyr::arrange(dplyr::across(.cols = c("variant", colnames(self %.% population %.% groups)))) |>
+        dplyr::group_by(dplyr::across(.cols = c("variant", colnames(self %.% population %.% groups)))) |>
         dplyr::group_split()
 
 
@@ -653,16 +653,21 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       # Impute zeros for missing states
       estimated_exposed_infected_states <- tidyr::expand_grid(
         "variant" = purrr::pluck(self %.% variant %.% variants, names, .default = "All"),
-        !!!self %.% population %.% groups,
         "state" = c(
           purrr::map_chr(seq_len(K), ~ paste0("E", .)),
           purrr::map_chr(seq_len(L), ~ paste0("I", .))
         ),
         "initial_condition" = 0
       ) |>
+        dplyr::cross_join(self %.% population %.% groups) |>
         dplyr::rows_update(
           estimated_exposed_infected_states,
-          by = c("variant", names(self %.% population %.% groups), "state")
+          by = c("variant", colnames(self %.% population %.% groups), "state")
+        ) |>
+        dplyr::select(
+          dplyr::all_of(
+            c("variant", colnames(self %.% population %.% groups), "state", "initial_condition")
+          )
         )
 
 
@@ -708,14 +713,19 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
           to = self %.% training_period %.% end,
           by = "1 day"
         ),
-        !!!self %.% population %.% groups,
         "variant" = purrr::pluck(self %.% variant %.% variants, names, .default = "All")
       ) |>
+        dplyr::cross_join(self %.% population %.% groups) |>
+        dplyr::select(
+          dplyr::all_of(
+            c("date", colnames(self %.% population %.% groups),  "variant")
+          )
+        ) |>
         dplyr::left_join(
           incidence_data,
-          by = c("date", names(self %.% population %.% groups), "variant")
+          by = c("date", colnames(self %.% population %.% groups), "variant")
         ) |>
-        dplyr::group_by(dplyr::across(c("variant", names(self %.% population %.% groups)))) |>
+        dplyr::group_by(dplyr::across(c("variant", colnames(self %.% population %.% groups)))) |>
         dplyr::group_map(~ {
           stats::approxfun(
             x = as.numeric(.x$date - max(.x$date), unit = "days"),
@@ -800,13 +810,20 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
       # Get R and S states from the last row
       estimated_recovered_susceptible_states <- tidyr::expand_grid(
         "variant" = purrr::pluck(self %.% variant %.% variants, names, .default = "All"),
-        !!!self %.% population %.% groups,
         "state" = paste0("R", seq.int(self %.% parameters %.% compartment_structure %.% R))
       ) |>
-        dplyr::add_row(
-          "variant" = NA,
-          !!!self %.% population %.% groups,
-          "state" = "S"
+        dplyr::cross_join(self %.% population %.% groups) |>
+        dplyr::select(
+          dplyr::all_of(
+            c("variant", colnames(self %.% population %.% groups),  "state")
+          )
+        )
+        dplyr::union_all(
+          dplyr::mutate(
+            self %.% population %.% groups,
+            "variant" = NA,
+            "state" = "S"
+          )
         ) |>
         dplyr::mutate(
           "initial_condition" = sol[nrow(sol), rs_state_indices + 1]
@@ -825,7 +842,7 @@ DiseasyModelOdeSeir <- R6::R6Class(                                             
         estimated_exposed_infected_states,
         estimated_recovered_susceptible_states
       ) |>
-        dplyr::arrange(dplyr::across(c("variant", names(self %.% population %.% groups), "state")))
+        dplyr::arrange(dplyr::across(c("variant", colnames(self %.% population %.% groups), "state")))
 
 
       # Normalise

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -176,12 +176,24 @@ DiseasyPopulation <- R6::R6Class(                                               
       .f = active_binding,
       name = "activity",
       expr = return(private %.% .DiseasyActivity)
+    ),
+
+
+    #' @field regions (`diseasy::DiseasyRegions`)\cr
+    #'   The local copy of an DiseasyRegions module. Read-only.
+    #' @seealso [diseasy::DiseasyRegions]
+    #' @importFrom diseasystore `%.%`
+    regions = purrr::partial(
+      .f = active_binding,
+      name = "regions",
+      expr = return(private %.% .DiseasyRegions)
     )
   ),
 
 
   private = list(
     .DiseasyActivity = NULL,
+    .DiseasyRegions = NULL,
 
     .age_cuts_lower = 0L
   )

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -173,7 +173,7 @@ DiseasyPopulation <- R6::R6Class(                                               
       self %.% groups |>
         dplyr::left_join(
           self %.% activity %.% map_population(
-            age_cuts_lower_out = self %.% age_cuts_lower,
+            age_cuts_lower = self %.% age_cuts_lower,
             age_groups_reference = names(self %.% activity %.% contact_basis %.% proportion),
             demography = demography
           ) |>
@@ -241,12 +241,12 @@ DiseasyPopulation <- R6::R6Class(                                               
       expr = return(private %.% .DiseasyActivity)
     ),
 
-                                                                                                                        # nolint start: documentation_template_linter, identation_linter
+
     #' @field regions (`diseasy::DiseasyRegions`)\cr
     #'   The local copy of an DiseasyRegions module. Read-only.
     #' @seealso [diseasy::DiseasyRegions]
     #' @importFrom diseasystore `%.%`
-    regions = purrr::partial(                                                                                           # nolint end: documentation_template_linter, identation_linter
+    regions = purrr::partial(
       .f = active_binding,
       name = "regions",
       expr = return(private %.% .DiseasyRegions)

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -241,12 +241,12 @@ DiseasyPopulation <- R6::R6Class(                                               
       expr = return(private %.% .DiseasyActivity)
     ),
 
-
+                                                                                                                        # nolint start: documentation_template_linter, identation_linter
     #' @field regions (`diseasy::DiseasyRegions`)\cr
     #'   The local copy of an DiseasyRegions module. Read-only.
     #' @seealso [diseasy::DiseasyRegions]
     #' @importFrom diseasystore `%.%`
-    regions = purrr::partial(
+    regions = purrr::partial(                                                                                           # nolint end: documentation_template_linter, identation_linter
       .f = active_binding,
       name = "regions",
       expr = return(private %.% .DiseasyRegions)

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -128,28 +128,30 @@ DiseasyPopulation <- R6::R6Class(                                               
 
   active = list(
 
-    #' @field groups (`named character()`)\cr
-    #'   The names of the demographic groups that have been configured in the module.
+    #' @field groups (`data.frame()`)\cr
+    #'   The demographic groups that have been configured in the module.
     groups = function() {
 
-      groups <- list(
-        "age_group" = diseasystore::age_labels(self %.% age_cuts_lower)
-      )
+      groups <- list()
 
-      # Check DiseasyRegions module is loaded
-      if (checkmate::test_class(self %.% regions, "DiseasyRegions")) {
+      # Age stratification
+      groups[["age_group"]] <- diseasystore::age_labels(self %.% age_cuts_lower)
 
-        regions <- self %.% regions %.% regions
-
-        if (is.null(regions)) {
-          regions <- unique(self %.% regions %.% demography %.% region)
-        }
-
-        groups[["region"]] <- sort(regions)
+      # Spatial stratification
+      if (is.null(self %.% regional_stratification)) {
+        groups[["region"]] <- "All"
+      } else if (checkmate::test_class(self %.% regions, "DiseasyRegions")) {
+        groups[["region"]] <- toString(
+          purrr::pluck(self %.% regions %.% regions, .default = "All")
+        )
       }
 
-      # Sort by name
-      return(groups[order(names(groups))])
+      # Unpack groups and sort by name
+      groups <- tidyr::expand_grid(
+        !!!groups[order(names(groups))]
+      )
+
+      return(groups)
     },
 
 

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -34,17 +34,17 @@ DiseasyPopulation <- R6::R6Class(                                               
     #' @description
     #'   Creates a new instance of the `DiseasyPopulation` [R6][R6::R6Class] class.
     #' @param age_cuts_lower `r rd_age_cuts_lower()`
-    #' @param regions `r rd_regions()`
+    #' @param regional_stratification `r rd_regional_stratification()`
     #' @param ...
     #'   Parameters sent to `DiseasyBaseModule` [R6][R6::R6Class] constructor
-    initialize = function(age_cuts_lower = 0L, regions = NULL, ...) {
+    initialize = function(age_cuts_lower = 0L, regional_stratification = NULL, ...) {
 
       # Pass additional arguments to the DiseasyBaseModule initializer
       super$initialize(...)
 
       # Pass arguments to methods
       self$stratify_age(age_cuts_lower)
-      self$stratify_regions(regions)
+      self$stratify_regions(regional_stratification)
 
     },
 
@@ -71,13 +71,13 @@ DiseasyPopulation <- R6::R6Class(                                               
 
     #' @description
     #'   Sets the spatial stratification of the model population.
-    #' @param regions `r rd_regions()`
+    #' @param regional_stratification `r rd_regional_stratification()`
     #' @return `r rd_side_effects`
-    stratify_regions = function(regions) {
+    stratify_regions = function(regional_stratification) {
       checkmate::assert_class(self %.% regions, "DiseasyRegions")
       checkmate::assert_choice(regions, self %.% regions %.% available_stratifications)
 
-      self$regions$set_regions(regions)
+      self$.regional_stratification <- regional_stratification
 
       return(invisible(NULL))
     },
@@ -200,6 +200,13 @@ DiseasyPopulation <- R6::R6Class(                                               
     },
 
 
+    #' @field regional_stratification `r rd_regional_stratification("field")`
+    regional_stratification = purrr::partial(
+      .f = active_binding,
+      name = "regional_stratification",
+      expr = return(private %.% .regional_stratification)
+    ),
+
 
     #' @field age_cuts_lower `r rd_age_cuts_lower("field")`
     age_cuts_lower = purrr::partial(
@@ -237,6 +244,6 @@ DiseasyPopulation <- R6::R6Class(                                               
     .DiseasyRegions = NULL,
 
     .age_cuts_lower = 0L,
-    .regions = NULL
+    .regional_stratification = NULL
   )
 )

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -161,12 +161,22 @@ DiseasyPopulation <- R6::R6Class(                                               
     #' @field population (`tibble`)\cr
     #'   The population groups and their sizes configured in the module.
     population = function() {
+      checkmate::assert_class(self %.% regions, "DiseasyRegions")
 
-      demography <- self %.% regions %.% demography
+      # Retrieve either the loaded demography or default to contact_basis
+      demography <- purrr::pluck(
+        self %.% regions %.% demography,
+        .default = self %.% activity %.% contact_basis %.% demography
+      ) |>
+        dplyr::mutate("proportion" = .data$population / sum(.data$population))
 
-      tidyr::expand_grid(!!!self %.% groups) |>
+      self %.% groups |>
         dplyr::left_join(
-          self %.% activity %.% map_population(self %.% age_cuts_lower, demography = demography) |>
+          self %.% activity %.% map_population(
+            age_cuts_lower_out = self %.% age_cuts_lower,
+            age_groups_reference = names(self %.% activity %.% contact_basis %.% proportion),
+            demography = demography
+          ) |>
             dplyr::summarise(
               "proportion" = sum(.data$proportion),
               "age_cuts_lower" = min(.data$age),

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -106,13 +106,21 @@ DiseasyPopulation <- R6::R6Class(                                               
       return(per_capita_contact_matrices)
     },
 
+
     #' @description `r rd_describe`
     describe = function() {
       printr("# DiseasyPopulation ##########################################")
+      printr("Stratifications:")
       if (identical(self %.% age_cuts_lower, 0L)) {
-        printr("No age stratification has been configured")
+        printr("Age: No age stratification has been configured")
       } else {
-        printr(glue::glue("Stratified by age: {toString(diseasystore::age_labels(self %.% age_cuts_lower))}"))
+        printr(glue::glue("Age: Stratified by age: {toString(diseasystore::age_labels(self %.% age_cuts_lower))}"))
+      }
+
+      if (is.null(private %.% .regions)) {
+        printr("Space: No spatial stratification has been configured")
+      } else {
+        printr(glue::glue("Space: Stratified by {private %.% .regions}"))
       }
     }
   ),

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -74,10 +74,13 @@ DiseasyPopulation <- R6::R6Class(                                               
     #' @param regional_stratification `r rd_regional_stratification()`
     #' @return `r rd_side_effects`
     stratify_regions = function(regional_stratification) {
-      checkmate::assert_class(self %.% regions, "DiseasyRegions")
-      checkmate::assert_choice(regions, self %.% regions %.% available_stratifications)
 
-      self$.regional_stratification <- regional_stratification
+      if (!is.null(regional_stratification)) {
+        checkmate::assert_class(self %.% regions, "DiseasyRegions")
+        checkmate::assert_choice(regions, self %.% regions %.% available_stratifications)
+      }
+
+      private$.regional_stratification <- regional_stratification
 
       return(invisible(NULL))
     },

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -34,15 +34,18 @@ DiseasyPopulation <- R6::R6Class(                                               
     #' @description
     #'   Creates a new instance of the `DiseasyPopulation` [R6][R6::R6Class] class.
     #' @param age_cuts_lower `r rd_age_cuts_lower()`
+    #' @param regions `r rd_regions()`
     #' @param ...
     #'   Parameters sent to `DiseasyBaseModule` [R6][R6::R6Class] constructor
-    initialize = function(age_cuts_lower = 0L, ...) {
+    initialize = function(age_cuts_lower = 0L, regions = NULL, ...) {
+
+      # Pass additional arguments to the DiseasyBaseModule initializer
+      super$initialize(...)
 
       # Pass arguments to methods
       self$stratify_age(age_cuts_lower)
+      self$stratify_regions(regions)
 
-      # Pass further arguments to the DiseasyBaseModule initializer
-      super$initialize(...)
     },
 
 
@@ -61,6 +64,22 @@ DiseasyPopulation <- R6::R6Class(                                               
 
       # Store the age_cuts as integer
       private$.age_cuts_lower <- as.integer(age_cuts_lower)
+
+      return(invisible(NULL))
+    },
+
+
+    #' @description
+    #'   Sets the spatial stratification of the model population.
+    #' @param regions `r rd_regions()`
+    #' @return `r rd_side_effects`
+    stratify_regions = function(regions) {
+      checkmate::assert_class(self %.% regions, "DiseasyRegions")
+      checkmate::assert_choice(regions, self %.% regions %.% available_stratifications)
+
+      self$regions$set_regions(regions)
+
+      return(invisible(NULL))
     },
 
 
@@ -108,6 +127,18 @@ DiseasyPopulation <- R6::R6Class(                                               
       groups <- list(
         "age_group" = diseasystore::age_labels(self %.% age_cuts_lower)
       )
+
+      # Check DiseasyRegions module is loaded
+      if (checkmate::test_class(self %.% regions, "DiseasyRegions")) {
+
+        regions <- self %.% regions %.% regions
+
+        if (is.null(regions)) {
+          regions <- unique(self %.% regions %.% demography %.% region)
+        }
+
+        groups[["region"]] <- sort(regions)
+      }
 
       # Sort by name
       return(groups[order(names(groups))])
@@ -195,6 +226,7 @@ DiseasyPopulation <- R6::R6Class(                                               
     .DiseasyActivity = NULL,
     .DiseasyRegions = NULL,
 
-    .age_cuts_lower = 0L
+    .age_cuts_lower = 0L,
+    .regions = NULL
   )
 )

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -37,10 +37,15 @@ DiseasyPopulation <- R6::R6Class(                                               
     #' @param regional_stratification `r rd_regional_stratification()`
     #' @param ...
     #'   Parameters sent to `DiseasyBaseModule` [R6][R6::R6Class] constructor
-    initialize = function(age_cuts_lower = 0L, regional_stratification = NULL, ...) {
+    initialize = function(age_cuts_lower = 0L, regional_stratification = NULL, region = NULL, ...) {
+      checkmate::assert_class(observables, "DiseasyObservables", null.ok = TRUE)
 
       # Pass additional arguments to the DiseasyBaseModule initializer
       super$initialize(...)
+
+      if (!is.null(region)) {
+        self$load_module(region)
+      }
 
       # Pass arguments to methods
       self$stratify_age(age_cuts_lower)

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -159,16 +159,18 @@ DiseasyPopulation <- R6::R6Class(                                               
     #'   The population groups and their sizes configured in the module.
     population = function() {
 
+      demography <- self %.% regions %.% demography
+
       tidyr::expand_grid(!!!self %.% groups) |>
         dplyr::left_join(
-          self %.% activity %.% map_population(self %.% age_cuts_lower) |>
+          self %.% activity %.% map_population(self %.% age_cuts_lower, demography = demography) |>
             dplyr::summarise(
               "proportion" = sum(.data$proportion),
               "age_cuts_lower" = min(.data$age),
               .by = "age_group_out"
             ) |>
             dplyr::transmute(
-              "population" = .data$proportion * sum(self %.% activity %.% contact_basis %.% population),
+              "population" = .data$proportion * sum(demography %.% population),
               .data$proportion,
               "age_group" = diseasystore::age_labels(.data$age_cuts_lower)
             ),

--- a/R/DiseasyRegions.R
+++ b/R/DiseasyRegions.R
@@ -311,6 +311,15 @@ DiseasyRegions <- R6::R6Class(                                                  
     ),
 
 
+    #' @field available_stratifications (`character()`)\cr
+    #'   The available levels of stratification supported. Read only.
+    available_stratifications = purrr::partial(
+      .f = active_binding,
+      name = "regions",
+      expr = list("region") # For DiseasyRegions, space can either not be startifed or stratified by region
+    ),
+
+
     #' @field adjacency `r rd_adjacency(type = "field")`
     adjacency = purrr::partial(
       .f = active_binding,

--- a/man/DiseasyActivity.Rd
+++ b/man/DiseasyActivity.Rd
@@ -344,13 +344,24 @@ Map population between age groups
   The function computes the proportion of population in the new and old age groups.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyActivity$map_population(age_cuts_lower)}
+    \preformatted{DiseasyActivity$map_population(
+  age_cuts_lower_out,
+  age_groups_reference = names(self$contact_basis$proportion),
+  demography = self$contact_basis$demography
+)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
+      \item{\code{age_cuts_lower_out}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
+      \item{\code{age_groups_reference}}{(\code{character()})\cr
+Age labels (created by \code{diseasystore::age_labels()} of reference data.}
+      \item{\code{demography}}{(\code{data.frame})\cr
+"A \code{data.frame} with the columns\\cr",
+"  * \code{age} (\code{integer()}) 1-year age group\\cr",
+"  * \code{population} (\code{numeric()}) size of population in age group\\cr",
+"  * \code{proportion} (\code{numeric()}) proportion of total population in age group\\cr",}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/DiseasyActivity.Rd
+++ b/man/DiseasyActivity.Rd
@@ -345,7 +345,7 @@ Map population between age groups
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{DiseasyActivity$map_population(
-  age_cuts_lower_out,
+  age_cuts_lower,
   age_groups_reference = names(self$contact_basis$proportion),
   demography = self$contact_basis$demography
 )}
@@ -354,7 +354,7 @@ Map population between age groups
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{age_cuts_lower_out}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
+      \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
       \item{\code{age_groups_reference}}{(\code{character()})\cr
 Age labels (created by \code{diseasystore::age_labels()} of reference data.}
       \item{\code{demography}}{(\code{data.frame})\cr

--- a/man/DiseasyModel.Rd
+++ b/man/DiseasyModel.Rd
@@ -15,10 +15,13 @@ Most notably, the model module facilitates:
 \item Module interfaces:
 The module contains the functional modules via its active bindings:
 \itemize{
-\item \verb{$activity}: \code{DiseasyActivity}
 \item \verb{$observables}: \code{DiseasyObservables}
+\item \verb{$population} : \code{DiseasyPopulation}
+\item \verb{$activity}: \code{DiseasyActivity}
+\item \verb{$region}: \code{DiseasyRegions}
 \item \verb{$season}: \code{DiseasySeason}
 \item \verb{$variant} : \code{DiseasyVariant}
+\item \verb{$immunity} : \code{DiseasyImmunity}
 }
 
 Configured instances of these modules can be provided during initialisation.
@@ -43,11 +46,13 @@ These functions define the "API" of the models and ensure the models can take pa
 
 \link{DiseasyActivity}
 
-\link{DiseasyImmunity}
+\link{DiseasyRegions}
 
 \link{DiseasySeason}
 
 \link{DiseasyVariant}
+
+\link{DiseasyImmunity}
 }
 \keyword{model-template-builder}
 \section{Super class}{
@@ -56,23 +61,26 @@ These functions define the "API" of the models and ensure the models can take pa
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
+    \item{\code{observables}}{(\code{diseasy::DiseasyObservables})\cr
+The local copy of a DiseasyObservables module. Read-only.}
+
     \item{\code{population}}{(\code{diseasy::DiseasyPopulation})\cr
 The local copy of a DiseasyPopulation module. Read-only.}
 
     \item{\code{activity}}{(\code{diseasy::DiseasyActivity})\cr
 The local copy of an DiseasyActivity module. Read-only.}
 
-    \item{\code{immunity}}{(\code{diseasy::DiseasyImmunity})\cr
-The local copy of a DiseasyImmunity module. Read-only.}
-
-    \item{\code{observables}}{(\code{diseasy::DiseasyObservables})\cr
-The local copy of a DiseasyObservables module. Read-only.}
+    \item{\code{region}}{(\code{diseasy::DiseasyRegions})\cr
+The local copy of an DiseasyRegions module. Read-only.}
 
     \item{\code{season}}{(\code{diseasy::DiseasySeason})\cr
 The local copy of a DiseasySeason module. Read-only.}
 
     \item{\code{variant}}{(\code{diseasy::.DiseasyVariant})\cr
 The local copy of a DiseasyVariant module. Read-only.}
+
+    \item{\code{immunity}}{(\code{diseasy::DiseasyImmunity})\cr
+The local copy of a DiseasyImmunity module. Read-only.}
 
     \item{\code{parameters}}{(\code{list()})\cr
 The parameters used in the model. Read-only.}
@@ -115,6 +123,7 @@ This module is typically not constructed directly but rather through \verb{Disea
   observables = FALSE,
   population = FALSE,
   activity = FALSE,
+  region = FALSE,
   season = FALSE,
   variant = FALSE,
   immunity = FALSE,
@@ -127,7 +136,7 @@ This module is typically not constructed directly but rather through \verb{Disea
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{observables, population, activity, season, variant, immunity}}{(\code{boolean} or \verb{R6::R6Class instance})\cr If a boolean is given, it dictates whether to load a new instance module of this class.\cr If an instance of the module is provided instead, a copy of this instance is added to the \code{DiseasyModel} instance. This copy is a "clone" of the instance at the time it is added and any subsequent changes to the instance will not reflect in the copy that is added to \code{DiseasyModel}.}
+      \item{\code{observables, population, activity, region, season, variant, immunity}}{(\code{boolean} or \verb{R6::R6Class instance})\cr If a boolean is given, it dictates whether to load a new instance module of this class.\cr If an instance of the module is provided instead, a copy of this instance is added to the \code{DiseasyModel} instance. This copy is a "clone" of the instance at the time it is added and any subsequent changes to the instance will not reflect in the copy that is added to \code{DiseasyModel}.}
       \item{\code{parameters}}{(\verb{named list()})\cr
 List of parameters to set for the model during initialization.
 

--- a/man/DiseasyModelOdeSeir.Rd
+++ b/man/DiseasyModelOdeSeir.Rd
@@ -124,6 +124,7 @@ in the model. Read only.}
   observables = FALSE,
   population = TRUE,
   activity = TRUE,
+  region = TRUE,
   season = TRUE,
   variant = TRUE,
   immunity = TRUE,
@@ -135,7 +136,7 @@ in the model. Read only.}
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{observables, population, activity, season, variant, immunity}}{(\code{boolean} or \verb{R6::R6Class instance})\cr If a boolean is given, it dictates whether to load a new instance module of this class.\cr If an instance of the module is provided instead, a copy of this instance is added to the \code{DiseasyModel} instance. This copy is a "clone" of the instance at the time it is added and any subsequent changes to the instance will not reflect in the copy that is added to \code{DiseasyModel}.}
+      \item{\code{observables, population, activity, region, season, variant, immunity}}{(\code{boolean} or \verb{R6::R6Class instance})\cr If a boolean is given, it dictates whether to load a new instance module of this class.\cr If an instance of the module is provided instead, a copy of this instance is added to the \code{DiseasyModel} instance. This copy is a "clone" of the instance at the time it is added and any subsequent changes to the instance will not reflect in the copy that is added to \code{DiseasyModel}.}
       \item{\code{parameters}}{(\verb{named list()})\cr
 List of parameters to set for the model during initialization.
 

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -85,7 +85,12 @@ The local copy of an DiseasyRegions module. Read-only.}
   Creates a new instance of the \code{DiseasyPopulation} \link[R6:R6Class]{R6} class.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyPopulation$new(age_cuts_lower = 0L, regional_stratification = NULL, ...)}
+    \preformatted{DiseasyPopulation$new(
+  age_cuts_lower = 0L,
+  regional_stratification = NULL,
+  region = NULL,
+  ...
+)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -49,6 +49,8 @@ The population groups and their sizes configured in the module.}
     \item{\code{population_proportion}}{(\code{numeric()})\cr
 The distribution of individuals across the demography groups defined in the module.}
 
+    \item{\code{regional_stratification}}{(\code{character()})\cr The level of spatial stratification of the population. Read only.}
+
     \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used. Read only.}
 
     \item{\code{activity}}{(\code{diseasy::DiseasyActivity})\cr
@@ -83,14 +85,14 @@ The local copy of an DiseasyRegions module. Read-only.}
   Creates a new instance of the \code{DiseasyPopulation} \link[R6:R6Class]{R6} class.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyPopulation$new(age_cuts_lower = 0L, regions = NULL, ...)}
+    \preformatted{DiseasyPopulation$new(age_cuts_lower = 0L, regional_stratification = NULL, ...)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{regional_stratification}}{(\code{character()})\cr The level of spatial stratification of the population.}
       \item{\code{...}}{Parameters sent to \code{DiseasyBaseModule} \link[R6:R6Class]{R6} constructor}
     }
     \if{html}{\out{</div>}}
@@ -126,13 +128,13 @@ The local copy of an DiseasyRegions module. Read-only.}
   Sets the spatial stratification of the model population.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyPopulation$stratify_regions(regions)}
+    \preformatted{DiseasyPopulation$stratify_regions(regional_stratification)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{regional_stratification}}{(\code{character()})\cr The level of spatial stratification of the population.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -40,8 +40,8 @@ See vignette("diseasy-population").
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
-    \item{\code{groups}}{(\verb{named character()})\cr
-The names of the demographic groups that have been configured in the module.}
+    \item{\code{groups}}{(\code{data.frame()})\cr
+The demographic groups that have been configured in the module.}
 
     \item{\code{population}}{(\code{tibble})\cr
 The population groups and their sizes configured in the module.}

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -30,6 +30,8 @@ See vignette("diseasy-population").
 }
 \seealso{
 \link{DiseasyActivity}
+
+\link{DiseasyRegions}
 }
 \keyword{functional-module}
 \section{Super class}{
@@ -51,6 +53,9 @@ The distribution of individuals across the demography groups defined in the modu
 
     \item{\code{activity}}{(\code{diseasy::DiseasyActivity})\cr
 The local copy of an DiseasyActivity module. Read-only.}
+
+    \item{\code{regions}}{(\code{diseasy::DiseasyRegions})\cr
+The local copy of an DiseasyRegions module. Read-only.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -64,6 +64,7 @@ The local copy of an DiseasyRegions module. Read-only.}
   \itemize{
     \item \href{#method-DiseasyPopulation-initialize}{\code{DiseasyPopulation$new()}}
     \item \href{#method-DiseasyPopulation-stratify_age}{\code{DiseasyPopulation$stratify_age()}}
+    \item \href{#method-DiseasyPopulation-stratify_regions}{\code{DiseasyPopulation$stratify_regions()}}
     \item \href{#method-DiseasyPopulation-per_capita_contact_matrices}{\code{DiseasyPopulation$per_capita_contact_matrices()}}
     \item \href{#method-DiseasyPopulation-describe}{\code{DiseasyPopulation$describe()}}
     \item \href{#method-DiseasyPopulation-clone}{\code{DiseasyPopulation$clone()}}
@@ -82,13 +83,14 @@ The local copy of an DiseasyRegions module. Read-only.}
   Creates a new instance of the \code{DiseasyPopulation} \link[R6:R6Class]{R6} class.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyPopulation$new(age_cuts_lower = 0L, ...)}
+    \preformatted{DiseasyPopulation$new(age_cuts_lower = 0L, regions = NULL, ...)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
+      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
       \item{\code{...}}{Parameters sent to \code{DiseasyBaseModule} \link[R6:R6Class]{R6} constructor}
     }
     \if{html}{\out{</div>}}
@@ -109,6 +111,28 @@ The local copy of an DiseasyRegions module. Read-only.}
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    \code{NULL} (called for side effects)
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-DiseasyPopulation-stratify_regions"></a>}}
+\if{latex}{\out{\hypertarget{method-DiseasyPopulation-stratify_regions}{}}}
+\subsection{\code{DiseasyPopulation$stratify_regions()}}{
+  Sets the spatial stratification of the model population.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DiseasyPopulation$stratify_regions(regions)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/DiseasyRegions.Rd
+++ b/man/DiseasyRegions.Rd
@@ -56,6 +56,9 @@ See the vignette("diseasy-regions") for examples of use.
   \describe{
     \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest.  Read only.}
 
+    \item{\code{available_stratifications}}{(\code{character()})\cr
+The available levels of stratification supported. Read only.}
+
     \item{\code{adjacency}}{(\code{data.frame(1)})\cr The adjacency (connectedness) of the regions. Effectively, the \code{adjacency} is a long-form of the adjacency-matrix\cr The \code{data.frame} must include the following columns:\cr - \code{from} (\code{character}): Region identifier.\cr - \code{to}   (\code{character}): Region identifier.\cr - \code{adjacency} (\code{numeric}): Strength of the connectedness.\cr Read only.}
 
     \item{\code{infection_flow_matrix}}{(\code{matrix})\cr

--- a/man/adjacency_meta_social_connectedness.Rd
+++ b/man/adjacency_meta_social_connectedness.Rd
@@ -6,7 +6,7 @@
 \title{Meta Social Connectedness Index as adjacency for NUTS 3 regions}
 \source{
 Meta Social Connectedness Index. Data accessed from the Humanitarian Data Exchange.
-Retrieved June 05, 2026,
+Retrieved June 04, 2026,
 See \url{https://data.humdata.org/dataset/social-connectedness-index} and
 \url{https://ai.meta.com/ai-for-good/docs/methodology-social-connectedness-index/}.
 }

--- a/pak.lock
+++ b/pak.lock
@@ -231,7 +231,7 @@
     },
     {
       "package": "distributional",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "binary": true
     },
     {
@@ -751,7 +751,7 @@
     },
     {
       "package": "readxl",
-      "version": "1.4.5",
+      "version": "1.5.0",
       "binary": true
     },
     {
@@ -816,7 +816,7 @@
     },
     {
       "package": "rstudioapi",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "binary": true
     },
     {

--- a/tests/testthat/test-DiseasyPopulation.R
+++ b/tests/testthat/test-DiseasyPopulation.R
@@ -31,10 +31,32 @@ test_that("$stratify_age() works", {
   population <- DiseasyPopulation$new()
   expect_identical(population %.% age_cuts_lower, 0L)
   hash_new_instance <- population$hash # Store the current hash
-  expect_identical(population$hash, hash_new_instance)
 
   # Change stratification (low resolution)
   population$stratify_age(age_cuts_lower = c(0, 30))
+  expect_identical(population %.% age_cuts_lower, c(0L, 30L))
+  hash_2_age_groups <- population$hash
+  expect_identical(population$hash, hash_2_age_groups)
+  expect_false(identical(hash_2_age_groups, hash_new_instance))
+
+  # Change stratification (high resolution)
+  population$stratify_age(age_cuts_lower = seq(0, 100, by = 20))
+  expect_identical(population %.% age_cuts_lower, c(0L, 20L, 40L, 60L, 80L, 100L))
+  expect_false(identical(population$hash, hash_new_instance))
+  expect_false(identical(population$hash, hash_2_age_groups))
+
+})
+
+
+test_that("$stratify_regions() works", {
+
+  # Creating an empty module
+  population <- DiseasyPopulation$new()
+  expect_null(population %.% regional_stratification)
+  hash_new_instance <- population$hash # Store the current hash
+
+  # Change stratification (low resolution)
+  population$stratify_regions(regional_stratification = "NUTS0")
   expect_identical(population %.% age_cuts_lower, c(0L, 30L))
   hash_2_age_groups <- population$hash
   expect_identical(population$hash, hash_2_age_groups)

--- a/tests/testthat/test-DiseasyPopulation.R
+++ b/tests/testthat/test-DiseasyPopulation.R
@@ -28,6 +28,7 @@ test_that("initialize works", {
 test_that("$stratify_age() works", {
 
   # Creating an empty module
+  # NB: No region module loaded so we cannot verify stratification is possible
   population <- DiseasyPopulation$new()
   expect_identical(population %.% age_cuts_lower, 0L)
   hash_new_instance <- population$hash # Store the current hash
@@ -50,24 +51,53 @@ test_that("$stratify_age() works", {
 
 test_that("$stratify_regions() works", {
 
-  # Creating an empty module
+  # We can only stratify by region if DiseasyRegions is loaded
   population <- DiseasyPopulation$new()
+  population$stratify_regions(regional_stratification = "region")
+  expect_null(population %.% regional_stratification) # But it should still show as no stratification
+
+
+  # Creating an empty module
+  region <- DiseasyRegions$new()
+  population <- DiseasyPopulation$new(region = region)
   expect_null(population %.% regional_stratification)
   hash_new_instance <- population$hash # Store the current hash
 
+
   # Change stratification (low resolution)
-  population$stratify_regions(regional_stratification = "NUTS0")
-  expect_identical(population %.% age_cuts_lower, c(0L, 30L))
-  hash_2_age_groups <- population$hash
-  expect_identical(population$hash, hash_2_age_groups)
-  expect_false(identical(hash_2_age_groups, hash_new_instance))
+  population$stratify_regions(regional_stratification = "region")
+  expect_identical(population %.% regional_stratification, "region")
+  hash_regions <- population$hash
+  expect_false(identical(hash_regions, hash_new_instance))
+
+
+  # `DiseasyRegions` only supports "region" or "null"
+  population$stratify_regions(regional_stratification = "NUTS 0")
+
+  rm(population)
+  rm(region)
+
+  # `DiseasyRegionsNuts` supports "null" or NUTS 0 - 3
+  region_nuts <- DiseasyRegionsNuts$new()
+  population <- DiseasyPopulation$new(region = region_nuts)
+  hash_new_instance <- population$hash # Store the current hash
+
+
+  # Change stratification (low resolution)
+  population$stratify_regions(regional_stratification = "NUTS 0")
+  expect_identical(population %.% regional_stratification, "NUTS 0")
+  hash_nuts_0 <- population$hash
+  expect_false(identical(hash_nuts_0, hash_new_instance))
+
 
   # Change stratification (high resolution)
-  population$stratify_age(age_cuts_lower = seq(0, 100, by = 20))
-  expect_identical(population %.% age_cuts_lower, c(0L, 20L, 40L, 60L, 80L, 100L))
+  population$stratify_regions(regional_stratification = "NUTS 3")
+  expect_identical(population %.% regional_stratification, "NUTS 3")
   expect_false(identical(population$hash, hash_new_instance))
-  expect_false(identical(population$hash, hash_2_age_groups))
+  expect_false(identical(population$hash, hash_nuts_0))
 
+  rm(population)
+  rm(region_nuts)
 })
 
 

--- a/tests/testthat/test-DiseasyPopulation.R
+++ b/tests/testthat/test-DiseasyPopulation.R
@@ -3,6 +3,23 @@ test_that("initialize works", {
   # Creating an empty module
   population <- DiseasyPopulation$new()
   expect_identical(population %.% age_cuts_lower, 0L)
+  expect_null(population %.% regional_stratification)
+
+  rm(population)
+
+
+  # Set age stratification during loading
+  population <- DiseasyPopulation$new(age_cuts_lower = c(20, 40, 60))
+  expect_identical(population %.% age_cuts_lower, c(20L, 40L, 60L))
+  expect_null(population %.% regional_stratification)
+
+  rm(population)
+
+
+  # Set spatial stratification during loading
+  population <- DiseasyPopulation$new(regional_stratification = "region")
+  expect_identical(population %.% age_cuts_lower, 0L)
+  expect_identical(population %.% regional_stratification, "region")
 
   rm(population)
 })


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR integrates `DiseasyRegions` into `DiseasyPopulation` to enable spatial stratification of the model population

### Approach
* `DiseasyRegions` added as loadable module for `DiseasyPopulation`
* Functions to stratify by region added to  `DiseasyPopulation`
* `map_population` in `DiseasyActivity` is made stand-alone

### Known issues
Possibly we need the `demography_nuts3` to be changed to a `demography_nuts2` dataset with 1-year age groups rather than 5-year age groups.

We need to be careful about the population mapping of contacts when the demography in `DiseasyRegions` is different from the demography in `contact_basis`. But this needs to be worked out in a different PR.

### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
