### PR TITLE
`DiseasyRegions`: Disambiguate meaning of "regions"

### DIFF
--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -222,11 +222,11 @@ rd_regional_stratification <- function(type = "param") {
 
 
 ## Templates for DiseasyRegions
-rd_regions <- function(type = "param") {
+rd_area <- function(type = "param") {
   checkmate::assert_choice(type, c("param", "field", "generators"))
   paste(
     "(`character()`)\\cr",
-    "The geographic regions of interest.",
+    "The geographic area (list of regions) of interest.",
 
     switch(
       type,

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -316,12 +316,12 @@ DiseasyPopulation <- R6::R6Class(                                               
       expr = return(private %.% .DiseasyActivity)
     ),
 
-                                                                                                                        # nolint start: documentation_template_linter, identation_linter
+
     #' @field regions (`diseasy::DiseasyRegions`)\cr
     #'   The local copy of an DiseasyRegions module. Read-only.
     #' @seealso [diseasy::DiseasyRegions]
     #' @importFrom diseasystore `%.%`
-    regions = purrr::partial(                                                                                           # nolint end: documentation_template_linter, identation_linter
+    regions = purrr::partial(
       .f = active_binding,
       name = "regions",
       expr = return(private %.% .DiseasyRegions)

--- a/R/DiseasyPopulation.R
+++ b/R/DiseasyPopulation.R
@@ -35,18 +35,18 @@ DiseasyPopulation <- R6::R6Class(                                               
     #'   Creates a new instance of the `DiseasyPopulation` [R6][R6::R6Class] class.
     #' @param age_cuts_lower `r rd_age_cuts_lower()`
     #' @param regional_stratification `r rd_regional_stratification()`
-    #' @param region  (`DiseasyRegions`)\cr
+    #' @param regions (`DiseasyRegions`)\cr
     #'   An instance of a regional module which should provide the demography of the population.
     #' @param ...
     #'   Parameters sent to `DiseasyBaseModule` [R6][R6::R6Class] constructor
-    initialize = function(age_cuts_lower = 0L, regional_stratification = NULL, region = NULL, ...) {
-      checkmate::assert_class(region, "DiseasyRegions", null.ok = TRUE)
+    initialize = function(age_cuts_lower = 0L, regional_stratification = NULL, regions = NULL, ...) {
+      checkmate::assert_class(regions, "DiseasyRegions", null.ok = TRUE)
 
       # Pass additional arguments to the DiseasyBaseModule initializer
       super$initialize(...)
 
-      if (!is.null(region)) {
-        self$load_module(region)
+      if (!is.null(regions)) {
+        self$load_module(regions)
       }
 
       # Pass arguments to methods

--- a/R/DiseasyRegions.R
+++ b/R/DiseasyRegions.R
@@ -25,22 +25,22 @@
 #'   )
 #'
 #'   # Restrict the model scope to two regions.
-#'   region <- DiseasyRegions$new(
-#'     regions = c("north", "south"),
+#'   regions <- DiseasyRegions$new(
+#'     area = c("north", "south"),
 #'     adjacency = adjacency,
 #'     demography = demography
 #'   )
 #'
 #'   # Active bindings return data for configured regions.
-#'   region %.% regions
-#'   region %.% demography
-#'   region %.% adjacency
+#'   regions %.% area
+#'   regions %.% demography
+#'   regions %.% adjacency
 #'
 #'   # Update the configured regional scope.
-#'   region$set_regions(regions = c("north", "south", "east"))
-#'   region$describe()
+#'   regions$set_area(area = c("north", "south", "east"))
+#'   regions$describe()
 #'
-#'   rm(region, demography, adjacency)
+#'   rm(regions, demography, adjacency)
 #'
 #' @return
 #'   A new instance of the `DiseasyRegions` [R6][R6::R6Class] class.
@@ -54,17 +54,17 @@ DiseasyRegions <- R6::R6Class(                                                  
 
     #' @description
     #'   Creates a new instance of the `DiseasyRegions` [R6][R6::R6Class] class.
-    #' @param regions `r rd_regions()`
+    #' @param area `r rd_area()`
     #' @param adjacency `r rd_adjacency()`
     #' @param demography `r rd_demography()`
     #' @param ...
     #'   Parameters sent to `DiseasyBaseModule` [R6][R6::R6Class] constructor.
-    initialize = function(regions = NULL, adjacency = NULL, demography = NULL, ...) {
+    initialize = function(area = NULL, adjacency = NULL, demography = NULL, ...) {
 
       # Load objects
       if (!is.null(demography)) self$set_demography(demography)
       if (!is.null(adjacency))  self$set_adjacency(adjacency)
-      if (!is.null(regions))    self$set_regions(regions)
+      if (!is.null(area))       self$set_area(area)
 
       # Pass further arguments to the DiseasyBaseModule initializer
       super$initialize(...)
@@ -73,25 +73,25 @@ DiseasyRegions <- R6::R6Class(                                                  
 
     #' @description
     #'   Sets the geographic regions of interest.
-    #' @param regions `r rd_regions()`
+    #' @param area `r rd_area()`
     #' @return `r rd_side_effects`
-    set_regions = function(regions) {
+    set_area = function(area) {
 
       # Check configuration works with existing adjacency and demography
       self$validate_configuration(
-        regions = sort(regions),
+        area = sort(area),
         adjacency = private %.% .adjacency,
         demography = private %.% .demography
       )
 
-      private$.regions <- sort(regions)
+      private$.area <- sort(area)
 
       return(invisible(NULL))
     },
 
 
     #' @description
-    #'   Sets the region adjacency data.
+    #'   Sets the regional adjacency data.
     #' @param adjacency `r rd_adjacency()`
     #' @param type `r rd_adjacency_type`
     #' @return `r rd_side_effects`
@@ -109,9 +109,9 @@ DiseasyRegions <- R6::R6Class(                                                  
       # Store the type of adjacency matrix
       attr(adjacency, "type") <- type
 
-      # Check configuration works with existing region and demography
+      # Check configuration works with existing area and demography
       self$validate_configuration(
-        regions = self %.% regions,
+        area = self %.% area,
         adjacency = adjacency,
         demography = private %.% .demography
       )
@@ -131,7 +131,7 @@ DiseasyRegions <- R6::R6Class(                                                  
 
       # Check configuration works with existing regions and adjacency
       self$validate_configuration(
-        regions = self %.% regions,
+        area = self %.% area,
         adjacency = private %.% .adjacency,
         demography = demography
       )
@@ -143,29 +143,29 @@ DiseasyRegions <- R6::R6Class(                                                  
 
 
     #' @description
-    #'   Check whether `regions`, `adjacency`, and `demography` are mutually consistent.
-    #' @param regions `r rd_regions()`
+    #'   Check whether `area`, `adjacency`, and `demography` are mutually consistent.
+    #' @param area `r rd_area()`
     #' @param adjacency `r rd_adjacency()`
     #' @param demography `r rd_demography()`
     #' @return `r rd_side_effects`
     #' @keywords internal
     validate_configuration = function(
-      regions,
+      area,
       adjacency,
       demography
     ) {
 
-      # Check regions are consistent with adjacency
-      if (!is.null(regions) && !is.null(adjacency)) {
-        if (length(intersect(regions, adjacency %.% from)) < 1) {
-          pkgcond::pkg_error("`regions` and `adjacency` must contain at least one common region.")
+      # Check area are consistent with adjacency
+      if (!is.null(area) && !is.null(adjacency)) {
+        if (length(intersect(area, adjacency %.% from)) < 1) {
+          pkgcond::pkg_error("`area` and `adjacency` must contain at least one common region.")
         }
       }
 
-      # Check regions are consistent with demography
-      if (!is.null(regions) && !is.null(demography)) {
-        if (length(intersect(regions, demography %.% region)) < 1) {
-          pkgcond::pkg_error("`regions` and `demography` must contain at least one common region.")
+      # Check area are consistent with demography
+      if (!is.null(area) && !is.null(demography)) {
+        if (length(intersect(area, demography %.% region)) < 1) {
+          pkgcond::pkg_error("`area` and `demography` must contain at least one common region.")
         }
       }
 
@@ -180,25 +180,25 @@ DiseasyRegions <- R6::R6Class(                                                  
       return(invisible(NULL))
     },
 
-                                                                                                                        # nolint start: documentation_template_linter, identation_linter
+
     #' @description
     #'   Create a logical filter for values matching one or more regions.
     #' @param values (`character()`)\cr
     #'   Values to filter, typically region identifiers.
-    #' @param regions (`character()` or `NULL`)\cr
+    #' @param area (`character()` or `NULL`)\cr
     #'   Region identifiers to match against. Defaults to the currently selected
-    #'   regions. If `NULL`, all values are matched.
+    #'   area. If `NULL`, all values are matched.
     #' @return
     #'   A `logical()` vector with the same length as `values`.
-    region_filter = function(values, regions = self %.% regions) {                                                      # nolint end: documentation_template_linter, identation_linter
+    region_filter = function(values, area = self %.% area) {
       checkmate::assert_character(values, any.missing = FALSE)
 
-      if (is.null(regions)) {
+      if (is.null(area)) {
         region_filter <- rep(TRUE, length(values))
         return(region_filter)
       }
 
-      region_filter <- values %in% regions
+      region_filter <- values %in% area
 
       return(region_filter)
     },
@@ -298,12 +298,12 @@ DiseasyRegions <- R6::R6Class(                                                  
     #' @description
     #'   Plot model outputs or module configuration spatially.
     #' @param data (`data.frame(1)`)\cr
-    #'   The data to plot spatially on the configured regions.
+    #'   The data to plot spatially on the configured area.
     #'   If `NULL`, the demography and adjacency of regions are plotted.
     #'   If `data.frame`, the first non-structural column is plotted.
     #'   Structural columns are `region`, `date`, `realisation_id`, and `weight`.
     #' @param shape_files (`sf` or `NULL`)\cr
-    #'   Shape files used to draw the configured regions.
+    #'   Shape files used to draw the configured area.
     #'   If `NULL`, `rnaturalearth::ne_countries()` is used.
     #'
     #'   If an `sf` object is supplied, region identifiers are guessed from:
@@ -312,7 +312,7 @@ DiseasyRegions <- R6::R6Class(                                                  
     #'   * `geo` (as in `giscoR::gisco_get_nuts()`)
     #'
     #'   If several candidate columns exist, the first candidate with any match
-    #'   to the configured regions is used.
+    #'   to the configured area is used.
     #' @return `r rd_side_effects`
     #' @seealso
     #' - [rnaturalearth::ne_countries()] for country-level shape files.
@@ -844,10 +844,10 @@ DiseasyRegions <- R6::R6Class(                                                  
     #' @description `r rd_describe`
     describe = function() {
       printr("# DiseasyRegions #############################################")
-      if (is.null(self %.% regions)) {
-        printr("Regions: No regions have been specified")
+      if (is.null(self %.% area)) {
+        printr("Area: No area has been specified")
       } else {
-        printr(glue::glue("Regions: {toString(self %.% regions)}"))
+        printr(glue::glue("Area: {toString(self %.% area)}"))
       }
 
       if (is.null(self %.% demography)) {
@@ -875,11 +875,11 @@ DiseasyRegions <- R6::R6Class(                                                  
 
 
   active  = list(
-    #' @field regions `r rd_regions(type = "field")`
-    regions = purrr::partial(
+    #' @field area `r rd_area(type = "field")`
+    area = purrr::partial(
       .f = active_binding,
-      name = "regions",
-      expr = return(private %.% .regions)
+      name = "area",
+      expr = return(private %.% .area)
     ),
 
 
@@ -929,10 +929,10 @@ DiseasyRegions <- R6::R6Class(                                                  
         if (is.null(adjacency)) {
           return(
             matrix(
-              data = 1 / sqrt(length(self %.% regions)),
-              nrow = length(self %.% regions),
-              ncol = length(self %.% regions),
-              dimnames = list(self %.% regions, self %.% regions)
+              data = 1 / sqrt(length(self %.% area)),
+              nrow = length(self %.% area),
+              ncol = length(self %.% area),
+              dimnames = list(self %.% area, self %.% area)
             )
           )
         }
@@ -958,7 +958,7 @@ DiseasyRegions <- R6::R6Class(                                                  
         }
 
         demography <- demography |>
-          dplyr::filter( # Filter demography to the given regions
+          dplyr::filter( # Filter demography to the given area
             self$region_filter(values = .data$region)
           ) |>
           dplyr::arrange(
@@ -974,7 +974,7 @@ DiseasyRegions <- R6::R6Class(                                                  
 
 
   private = list(
-    .regions = NULL,
+    .area = NULL,
     .adjacency = NULL,
     .demography = NULL
   )
@@ -990,30 +990,30 @@ DiseasyRegionsNuts <- R6::R6Class(                                              
   public = list(
 
     #' @description
-    #'   Check whether regions, adjacency, and demography are mutually consistent
+    #'   Check whether area, adjacency, and demography are mutually consistent
     #'   and complete under NUTS hierarchy semantics.
-    #' @param regions `r rd_regions()`
+    #' @param area `r rd_area()`
     #' @param adjacency `r rd_adjacency()`
     #' @param demography `r rd_demography()`
     #' @return `r rd_side_effects`
-    validate_configuration = function(regions, adjacency, demography) {
+    validate_configuration = function(area, adjacency, demography) {
 
       valid_nuts <- nuts$region
 
-      if (!checkmate::test_subset(self %.% regions, valid_nuts)) {
+      if (!checkmate::test_subset(self %.% area, valid_nuts)) {
         pkgcond::pkg_warning(
           glue::glue(
-            "Some configured regions are not valid NUTS regions: {toString(setdiff(self %.% regions, valid_nuts))}"
+            "Some of the configured area are not valid NUTS regions: {toString(setdiff(self %.% area, valid_nuts))}"
           )
         )
       }
 
-      # Helper function to retrieve all NUTS codes for the given regions
+      # Helper function to retrieve all NUTS codes for the given area
       nuts_at_resolution <- function(nuts_level) {
         nuts |>
           dplyr::filter(level <= nuts_level) |>
           dplyr::slice_max(.data$level, by = "country") |>
-          dplyr::filter(self$region_filter(.data$region, regions)) |>
+          dplyr::filter(self$region_filter(.data$region, area)) |>
           dplyr::pull("region")
       }
 
@@ -1028,11 +1028,11 @@ DiseasyRegionsNuts <- R6::R6Class(                                              
           pkgcond::pkg_error("`adjacency` has more data for more than one NUTS level")
         }
 
-        if (!is.null(regions)) {
+        if (!is.null(area)) {
 
           # Get all nuts code within scope
           all_nuts_within_scope <- nuts_at_resolution(adjacency_resolution) |>
-            purrr::keep(~ any(stringr::str_starts(., regions)))
+            purrr::keep(~ any(stringr::str_starts(., area)))
 
           missing_regions <- setdiff(all_nuts_within_scope, adjacency$from)
 
@@ -1057,11 +1057,11 @@ DiseasyRegionsNuts <- R6::R6Class(                                              
           pkgcond::pkg_error("`demography` has more data for more than one demography level")
         }
 
-        if (!is.null(regions)) {
+        if (!is.null(area)) {
 
           # Get all nuts code within scope
           all_nuts_within_scope <- nuts_at_resolution(demography_resolution) |>
-            purrr::keep(~ any(stringr::str_starts(., regions)))
+            purrr::keep(~ any(stringr::str_starts(., area)))
 
           missing_regions <- setdiff(all_nuts_within_scope, demography$region)
 
@@ -1080,26 +1080,25 @@ DiseasyRegionsNuts <- R6::R6Class(                                              
     },
 
 
-                                                                                                                        # nolint start: documentation_template_linter, identation_linter
     #' @description
     #'   Create a logical filter using NUTS hierarchy prefix matching.
     #' @param values (`character()`)\cr
     #'   Values to filter, typically NUTS codes.
-    #' @param regions (`character()` or `NULL`)\cr
+    #' @param area (`character()` or `NULL`)\cr
     #'   Region identifiers to match against. Defaults to the currently selected
-    #'   regions. If `NULL`, all values are matched.
+    #'   area. If `NULL`, all values are matched.
     #' @return
     #'   A `logical()` vector with the same length as `values`.
-    region_filter = function(values, regions = self %.% regions) {                                                      # nolint end: documentation_template_linter, identation_linter
+    region_filter = function(values, area = self %.% area) {
       checkmate::assert_character(values, any.missing = FALSE)
 
-      if (is.null(regions)) {
+      if (is.null(area)) {
         region_filter <- rep(TRUE, length(values))
         return(region_filter)
       }
 
       region_filter <- purrr::reduce(
-        .x = purrr::map(regions, ~ stringr::str_starts(values, .x)),
+        .x = purrr::map(area, ~ stringr::str_starts(values, .x)),
         .f = `|`,
         .init = FALSE
       )

--- a/R/DiseasyRegions.R
+++ b/R/DiseasyRegions.R
@@ -185,20 +185,20 @@ DiseasyRegions <- R6::R6Class(                                                  
     #'   Create a logical filter for values matching one or more regions.
     #' @param values (`character()`)\cr
     #'   Values to filter, typically region identifiers.
-    #' @param area (`character()` or `NULL`)\cr
+    #' @param target_area (`character()` or `NULL`)\cr
     #'   Region identifiers to match against. Defaults to the currently selected
     #'   area. If `NULL`, all values are matched.
     #' @return
     #'   A `logical()` vector with the same length as `values`.
-    region_filter = function(values, area = self %.% area) {
+    region_filter = function(values, target_area = self %.% area) {
       checkmate::assert_character(values, any.missing = FALSE)
 
-      if (is.null(area)) {
+      if (is.null(target_area)) {
         region_filter <- rep(TRUE, length(values))
         return(region_filter)
       }
 
-      region_filter <- values %in% area
+      region_filter <- values %in% target_area
 
       return(region_filter)
     },
@@ -1084,21 +1084,21 @@ DiseasyRegionsNuts <- R6::R6Class(                                              
     #'   Create a logical filter using NUTS hierarchy prefix matching.
     #' @param values (`character()`)\cr
     #'   Values to filter, typically NUTS codes.
-    #' @param area (`character()` or `NULL`)\cr
+    #' @param target_area (`character()` or `NULL`)\cr
     #'   Region identifiers to match against. Defaults to the currently selected
     #'   area. If `NULL`, all values are matched.
     #' @return
     #'   A `logical()` vector with the same length as `values`.
-    region_filter = function(values, area = self %.% area) {
+    region_filter = function(values, target_area = self %.% area) {
       checkmate::assert_character(values, any.missing = FALSE)
 
-      if (is.null(area)) {
+      if (is.null(target_area)) {
         region_filter <- rep(TRUE, length(values))
         return(region_filter)
       }
 
       region_filter <- purrr::reduce(
-        .x = purrr::map(area, ~ stringr::str_starts(values, .x)),
+        .x = purrr::map(target_area, ~ stringr::str_starts(values, .x)),
         .f = `|`,
         .init = FALSE
       )

--- a/R/generate_adjacency_meta.R
+++ b/R/generate_adjacency_meta.R
@@ -10,20 +10,18 @@
 #' @description
 #'   Generate adjacency data between NUTS 3 regions from Meta Social Connectedness
 #'   Index.
-#' @param regions `r rd_regions("generators")`
+#' @param area `r rd_area("generators")`
 #' @return
 #'   `r rd_adjacency("return")`
 #' @examples
 #' \dontrun{
-#' adjacency_meta_nordic <- generate_adjacency_meta(regions = c("DK", "FI", "IS", "NO", "SE"))
+#' adjacency_meta_nordic <- generate_adjacency_meta(area = c("DK", "FI", "IS", "NO", "SE"))
 #' }
 #' @keywords data-generators
 #' @export
 #' @importFrom diseasystore `%.%`
-generate_adjacency_meta <- function(
-  regions = NULL
-) {
-  checkmate::assert_character(regions, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
+generate_adjacency_meta <- function(area = NULL) {
+  checkmate::assert_character(area, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
 
   missing_packages <- purrr::discard(c("countrycode", "countrycode", "tibble"), rlang::is_installed)
 
@@ -55,7 +53,7 @@ generate_adjacency_meta <- function(
     )
 
 
-  if (is.null(regions)) {
+  if (is.null(area)) {
 
     # Keep regions in our NUTS list
     adjacency_meta <- adjacency_meta |>
@@ -68,14 +66,14 @@ generate_adjacency_meta <- function(
     adjacency_meta <- adjacency_meta |>
       dplyr::filter(
         purrr::reduce(
-          .x = purrr::map(regions, ~ stringr::str_starts(.data$from, .x)),
+          .x = purrr::map(area, ~ stringr::str_starts(.data$from, .x)),
           .f = `|`,
           .init = FALSE
         )
       ) |>
       dplyr::filter(
         purrr::reduce(
-          .x = purrr::map(regions, ~ stringr::str_starts(.data$to, .x)),
+          .x = purrr::map(area, ~ stringr::str_starts(.data$to, .x)),
           .f = `|`,
           .init = FALSE
         )

--- a/R/generate_contact_basis.R
+++ b/R/generate_contact_basis.R
@@ -3,7 +3,7 @@
 #' @description
 #'   Generate the contact-basis object used by `diseasy` from `contactdata`
 #'   contact matrices and country-level demography.
-#' @param regions `r rd_regions("generators")`
+#' @param area `r rd_area("generators")`
 #' @return
 #'   A named list of contact-basis objects, using the current package data
 #'   structure.
@@ -14,10 +14,8 @@
 #' @keywords data-generators
 #' @export
 #' @importFrom diseasystore `%.%`
-generate_contact_basis <- function(
-  regions = NULL
-) {
-  checkmate::assert_character(regions, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
+generate_contact_basis <- function(area = NULL) {
+  checkmate::assert_character(area, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
 
   missing_packages <- purrr::discard(c("countrycode", "countrycode", "tibble"), rlang::is_installed)
 
@@ -30,7 +28,7 @@ generate_contact_basis <- function(
   age_cuts_lower <- (0:15) * 5
   age_labels <- diseasystore::age_labels(age_cuts_lower)
 
-  demography <- generate_demography(regions)
+  demography <- generate_demography(area)
 
   countries <- contactdata::list_countries()
   country_codes <- purrr::map_chr(

--- a/R/generate_demography.R
+++ b/R/generate_demography.R
@@ -3,7 +3,7 @@
 #' @description
 #'   Generate the country-level demography data used by `diseasy` from the
 #'   U.S. Census Bureau International Database.
-#' @param regions `r rd_regions("generators")`
+#' @param area `r rd_area("generators")`
 #' @param year (`integer(1)`)\cr
 #'   The year to keep from the source data.
 #' @param idb_zip (`character(1)`)\cr
@@ -12,18 +12,18 @@
 #'   A `data.frame` with columns `region`, `age`, and `population`.
 #' @examples
 #' \dontrun{
-#' demography <- generate_demography(regions = c("DK", "FI", "IS", "NO", "SE"))
+#' demography <- generate_demography(area = c("DK", "FI", "IS", "NO", "SE"))
 #' }
 #' @keywords data-generators
 #' @export
 #' @importFrom diseasystore `%.%`
 generate_demography <- function(
-  regions = NULL,
+  area = NULL,
   year = 2020L,
   idb_zip = "https://www.census.gov/data-tools/demo/data/idb/dataset/idbzip.zip"
 ) {
   coll <- checkmate::makeAssertCollection()
-  checkmate::assert_character(regions, any.missing = FALSE, unique = TRUE, null.ok = TRUE, add = coll)
+  checkmate::assert_character(area, any.missing = FALSE, unique = TRUE, null.ok = TRUE, add = coll)
   checkmate::assert_integerish(year, len = 1, lower = 1950, add = coll)
   checkmate::assert_string(idb_zip, add = coll)
   checkmate::reportAssertions(coll)
@@ -46,8 +46,8 @@ generate_demography <- function(
     show_col_types = FALSE
   )
 
-  if (!is.null(regions)) {
-    idb_1yr <- dplyr::filter(idb_1yr, stringr::str_sub(.data$GEO_ID, -2, -1) %in% regions)
+  if (!is.null(area)) {
+    idb_1yr <- dplyr::filter(idb_1yr, stringr::str_sub(.data$GEO_ID, -2, -1) %in% area)
   }
 
   demography <- idb_1yr |>

--- a/R/generate_demography_nuts3.R
+++ b/R/generate_demography_nuts3.R
@@ -3,7 +3,7 @@
 #' @description
 #'   Generate NUTS3 demography data and the corresponding NUTS region lookup
 #'   from Eurostat dataset `demo_r_pjangrp3`.
-#' @param regions `r rd_regions("generators")`
+#' @param area `r rd_area("generators")`
 #' @param cache (`logical(1)`)\cr
 #'   Passed to [eurostat::get_eurostat()].
 #' @param output_nuts (`logical(1)`)\cr
@@ -12,13 +12,13 @@
 #'   A named list with elements `demography_nuts3` and `nuts`.
 #' @examples
 #' \dontrun{
-#' nuts_data <- generate_demography_nuts3(regions = c("DK", "FI", "IS", "NO", "SE"))
+#' nuts_data <- generate_demography_nuts3(area = c("DK", "FI", "IS", "NO", "SE"))
 #' }
 #' @keywords data-generators
 #' @export
 #' @importFrom diseasystore `%.%`
-generate_demography_nuts3 <- function(regions = NULL, cache = FALSE, output_nuts = FALSE) {
-  checkmate::assert_character(regions, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
+generate_demography_nuts3 <- function(area = NULL, cache = FALSE, output_nuts = FALSE) {
+  checkmate::assert_character(area, any.missing = FALSE, unique = TRUE, null.ok = TRUE, pattern = r"{[A-Z]{2}}")
   checkmate::assert_flag(cache)
 
   missing_packages <- purrr::discard(c("countrycode", "eurostat", "tibble"), rlang::is_installed)
@@ -158,7 +158,7 @@ generate_demography_nuts3 <- function(regions = NULL, cache = FALSE, output_nuts
 
   checkmate::assert_data_frame(lowest_nuts_lack_data, max.rows = 0)
 
-  if (is.null(regions)) {
+  if (is.null(area)) {
 
     # Keep regions in our NUTS list
     demography_nuts <- demography_nuts |>
@@ -170,7 +170,7 @@ generate_demography_nuts3 <- function(regions = NULL, cache = FALSE, output_nuts
     demography_nuts <- demography_nuts |>
       dplyr::filter(
         purrr::reduce(
-          .x = purrr::map(regions, ~ stringr::str_starts(.data$region, .x)),
+          .x = purrr::map(area, ~ stringr::str_starts(.data$region, .x)),
           .f = `|`,
           .init = FALSE
         )

--- a/data-raw/adjacency_meta.R
+++ b/data-raw/adjacency_meta.R
@@ -1,5 +1,5 @@
 adjacency_meta_nordic_nuts <- generate_adjacency_meta(
-  regions = c("DK", "FI", "IS", "NO", "SE")
+  area = c("DK", "FI", "IS", "NO", "SE")
 ) |>
   dplyr::inner_join(dplyr::select(nuts, "region"), by = c("from" = "region")) |>
   dplyr::inner_join(dplyr::select(nuts, "region"), by = c("to" = "region"))

--- a/data-raw/contact_basis_nordic.R
+++ b/data-raw/contact_basis_nordic.R
@@ -1,5 +1,5 @@
 contact_basis_nordic <- generate_contact_basis(
-  regions = c("DK", "FI", "IS", "NO", "SE")
+  area = c("DK", "FI", "IS", "NO", "SE")
 )
 
 usethis::use_data(contact_basis_nordic, overwrite = TRUE)

--- a/data-raw/demography_nordic.R
+++ b/data-raw/demography_nordic.R
@@ -1,5 +1,5 @@
 demography_nordic <- generate_demography(
-  regions = c("DK", "FI", "IS", "NO", "SE")
+  area = c("DK", "FI", "IS", "NO", "SE")
 )
 
 usethis::use_data(demography_nordic, overwrite = TRUE)

--- a/data-raw/demography_nordic_nuts3.R
+++ b/data-raw/demography_nordic_nuts3.R
@@ -1,5 +1,5 @@
 output <- generate_demography_nuts3(
-  regions = c("DK", "FI", "IS", "NO", "SE"),
+  area = c("DK", "FI", "IS", "NO", "SE"),
   output_nuts = TRUE
 )
 

--- a/man/DiseasyPopulation.Rd
+++ b/man/DiseasyPopulation.Rd
@@ -89,7 +89,7 @@ The local copy of an DiseasyRegions module. Read-only.}
     \preformatted{DiseasyPopulation$new(
   age_cuts_lower = 0L,
   regional_stratification = NULL,
-  region = NULL,
+  regions = NULL,
   ...
 )}
     \if{html}{\out{</div>}}
@@ -99,7 +99,7 @@ The local copy of an DiseasyRegions module. Read-only.}
     \describe{
       \item{\code{age_cuts_lower}}{(\code{integer()})\cr vector of ages defining the lower bound for each age group. If \code{NULL}, age groups of contact_basis is used.}
       \item{\code{regional_stratification}}{(\code{character()})\cr The level of spatial stratification of the population.}
-      \item{\code{region}}{(\code{DiseasyRegions})\cr
+      \item{\code{regions}}{(\code{DiseasyRegions})\cr
 An instance of a regional module which should provide the demography of the population.}
       \item{\code{...}}{Parameters sent to \code{DiseasyBaseModule} \link[R6:R6Class]{R6} constructor}
     }

--- a/man/DiseasyRegions.Rd
+++ b/man/DiseasyRegions.Rd
@@ -221,7 +221,7 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
   Create a logical filter for values matching one or more regions.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegions$region_filter(values, area = self \%.\% area)}
+    \preformatted{DiseasyRegions$region_filter(values, target_area = self \%.\% area)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -229,7 +229,7 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
     \describe{
       \item{\code{values}}{(\code{character()})\cr
 Values to filter, typically region identifiers.}
-      \item{\code{area}}{(\code{character()} or \code{NULL})\cr
+      \item{\code{target_area}}{(\code{character()} or \code{NULL})\cr
 Region identifiers to match against. Defaults to the currently selected
 area. If \code{NULL}, all values are matched.}
     }
@@ -421,7 +421,7 @@ and complete under NUTS hierarchy semantics.
   Create a logical filter using NUTS hierarchy prefix matching.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegionsNuts$region_filter(values, area = self \%.\% area)}
+    \preformatted{DiseasyRegionsNuts$region_filter(values, target_area = self \%.\% area)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -429,7 +429,7 @@ and complete under NUTS hierarchy semantics.
     \describe{
       \item{\code{values}}{(\code{character()})\cr
 Values to filter, typically NUTS codes.}
-      \item{\code{area}}{(\code{character()} or \code{NULL})\cr
+      \item{\code{target_area}}{(\code{character()} or \code{NULL})\cr
 Region identifiers to match against. Defaults to the currently selected
 area. If \code{NULL}, all values are matched.}
     }

--- a/man/DiseasyRegions.Rd
+++ b/man/DiseasyRegions.Rd
@@ -33,22 +33,22 @@ See the vignette("diseasy-regions") for examples of use.
   )
 
   # Restrict the model scope to two regions.
-  region <- DiseasyRegions$new(
-    regions = c("north", "south"),
+  regions <- DiseasyRegions$new(
+    area = c("north", "south"),
     adjacency = adjacency,
     demography = demography
   )
 
   # Active bindings return data for configured regions.
-  region \%.\% regions
-  region \%.\% demography
-  region \%.\% adjacency
+  regions \%.\% area
+  regions \%.\% demography
+  regions \%.\% adjacency
 
   # Update the configured regional scope.
-  region$set_regions(regions = c("north", "south", "east"))
-  region$describe()
+  regions$set_area(area = c("north", "south", "east"))
+  regions$describe()
 
-  rm(region, demography, adjacency)
+  rm(regions, demography, adjacency)
 
 }
 \seealso{
@@ -65,7 +65,7 @@ See the vignette("diseasy-regions") for examples of use.
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
-    \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. Read only.}
+    \item{\code{area}}{(\code{character()})\cr The geographic area (list of regions) of interest. Read only.}
 
     \item{\code{available_stratifications}}{(\code{character()})\cr
 The available levels of stratification supported. Read only.}
@@ -83,7 +83,7 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
 \subsection{Public methods}{
   \itemize{
     \item \href{#method-DiseasyRegions-initialize}{\code{DiseasyRegions$new()}}
-    \item \href{#method-DiseasyRegions-set_regions}{\code{DiseasyRegions$set_regions()}}
+    \item \href{#method-DiseasyRegions-set_area}{\code{DiseasyRegions$set_area()}}
     \item \href{#method-DiseasyRegions-set_adjacency}{\code{DiseasyRegions$set_adjacency()}}
     \item \href{#method-DiseasyRegions-set_demography}{\code{DiseasyRegions$set_demography()}}
     \item \href{#method-DiseasyRegions-validate_configuration}{\code{DiseasyRegions$validate_configuration()}}
@@ -108,13 +108,13 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
   Creates a new instance of the \code{DiseasyRegions} \link[R6:R6Class]{R6} class.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegions$new(regions = NULL, adjacency = NULL, demography = NULL, ...)}
+    \preformatted{DiseasyRegions$new(area = NULL, adjacency = NULL, demography = NULL, ...)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{area}}{(\code{character()})\cr The geographic area (list of regions) of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
       \item{\code{adjacency}}{(\code{data.frame(1)})\cr The adjacency (connectedness) of the regions. Effectively, the \code{adjacency} is a long-form of the adjacency-matrix\cr The \code{data.frame} must include the following columns:\cr - \code{from} (\code{character}): Region identifier.\cr - \code{to}   (\code{character}): Region identifier.\cr - \code{adjacency} (\code{numeric}): Strength of the connectedness.\cr The \code{from} and \code{to} columns must contain the same set of regions. For "movement" inputs, rows are normalised before deriving the Theta matrix. For "infection-flow" inputs, values are interpreted directly as the Theta matrix.}
       \item{\code{demography}}{(\code{data.frame(1)})\cr The demography of the population per region.\cr The \code{data.frame} must include the following columns:\cr * \code{region} (\code{character}) Region identifier.\cr * \code{...} Optional additional stratification columns (e.g. sex, ethnicity).\cr * \code{population} (\code{numeric}) Number of individuals in the group.}
       \item{\code{...}}{Parameters sent to \code{DiseasyBaseModule} \link[R6:R6Class]{R6} constructor.}
@@ -124,19 +124,19 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-DiseasyRegions-set_regions"></a>}}
-\if{latex}{\out{\hypertarget{method-DiseasyRegions-set_regions}{}}}
-\subsection{\code{DiseasyRegions$set_regions()}}{
+\if{html}{\out{<a id="method-DiseasyRegions-set_area"></a>}}
+\if{latex}{\out{\hypertarget{method-DiseasyRegions-set_area}{}}}
+\subsection{\code{DiseasyRegions$set_area()}}{
   Sets the geographic regions of interest.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegions$set_regions(regions)}
+    \preformatted{DiseasyRegions$set_area(area)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{area}}{(\code{character()})\cr The geographic area (list of regions) of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
     }
     \if{html}{\out{</div>}}
   }
@@ -149,7 +149,7 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
 \if{html}{\out{<a id="method-DiseasyRegions-set_adjacency"></a>}}
 \if{latex}{\out{\hypertarget{method-DiseasyRegions-set_adjacency}{}}}
 \subsection{\code{DiseasyRegions$set_adjacency()}}{
-  Sets the region adjacency data.
+  Sets the regional adjacency data.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{DiseasyRegions$set_adjacency(adjacency, type = c("movement", "infection-flow"))}
@@ -194,16 +194,16 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
 \if{html}{\out{<a id="method-DiseasyRegions-validate_configuration"></a>}}
 \if{latex}{\out{\hypertarget{method-DiseasyRegions-validate_configuration}{}}}
 \subsection{\code{DiseasyRegions$validate_configuration()}}{
-  Check whether \code{regions}, \code{adjacency}, and \code{demography} are mutually consistent.
+  Check whether \code{area}, \code{adjacency}, and \code{demography} are mutually consistent.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegions$validate_configuration(regions, adjacency, demography)}
+    \preformatted{DiseasyRegions$validate_configuration(area, adjacency, demography)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{area}}{(\code{character()})\cr The geographic area (list of regions) of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
       \item{\code{adjacency}}{(\code{data.frame(1)})\cr The adjacency (connectedness) of the regions. Effectively, the \code{adjacency} is a long-form of the adjacency-matrix\cr The \code{data.frame} must include the following columns:\cr - \code{from} (\code{character}): Region identifier.\cr - \code{to}   (\code{character}): Region identifier.\cr - \code{adjacency} (\code{numeric}): Strength of the connectedness.\cr The \code{from} and \code{to} columns must contain the same set of regions. For "movement" inputs, rows are normalised before deriving the Theta matrix. For "infection-flow" inputs, values are interpreted directly as the Theta matrix.}
       \item{\code{demography}}{(\code{data.frame(1)})\cr The demography of the population per region.\cr The \code{data.frame} must include the following columns:\cr * \code{region} (\code{character}) Region identifier.\cr * \code{...} Optional additional stratification columns (e.g. sex, ethnicity).\cr * \code{population} (\code{numeric}) Number of individuals in the group.}
     }
@@ -221,7 +221,7 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
   Create a logical filter for values matching one or more regions.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegions$region_filter(values, regions = self \%.\% regions)}
+    \preformatted{DiseasyRegions$region_filter(values, area = self \%.\% area)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -229,9 +229,9 @@ The "Theta" matrix (see \code{vignette("diseasy-regions")}) that describes flow 
     \describe{
       \item{\code{values}}{(\code{character()})\cr
 Values to filter, typically region identifiers.}
-      \item{\code{regions}}{(\code{character()} or \code{NULL})\cr
+      \item{\code{area}}{(\code{character()} or \code{NULL})\cr
 Region identifiers to match against. Defaults to the currently selected
-regions. If \code{NULL}, all values are matched.}
+area. If \code{NULL}, all values are matched.}
     }
     \if{html}{\out{</div>}}
   }
@@ -299,12 +299,12 @@ regions. If \code{NULL}, all values are matched.}
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{data}}{(\code{data.frame(1)})\cr
-The data to plot spatially on the configured regions.
+The data to plot spatially on the configured area.
 If \code{NULL}, the demography and adjacency of regions are plotted.
 If \code{data.frame}, the first non-structural column is plotted.
 Structural columns are \code{region}, \code{date}, \code{realisation_id}, and \code{weight}.}
       \item{\code{shape_files}}{(\code{sf} or \code{NULL})\cr
-Shape files used to draw the configured regions.
+Shape files used to draw the configured area.
 If \code{NULL}, \code{rnaturalearth::ne_countries()} is used.
 
 If an \code{sf} object is supplied, region identifiers are guessed from:
@@ -315,7 +315,7 @@ If an \code{sf} object is supplied, region identifiers are guessed from:
 }
 
 If several candidate columns exist, the first candidate with any match
-to the configured regions is used.}
+to the configured area is used.}
     }
     \if{html}{\out{</div>}}
   }
@@ -385,25 +385,25 @@ The available levels of stratification supported. Read only.}
   <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="describe"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-describe'><code>DiseasyRegions$describe()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="initialize"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-initialize'><code>DiseasyRegions$initialize()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="set_adjacency"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-set_adjacency'><code>DiseasyRegions$set_adjacency()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="set_area"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-set_area'><code>DiseasyRegions$set_area()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="set_demography"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-set_demography'><code>DiseasyRegions$set_demography()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="diseasy" data-topic="DiseasyRegions" data-id="set_regions"><a href='../../diseasy/html/DiseasyRegions.html#method-DiseasyRegions-set_regions'><code>DiseasyRegions$set_regions()</code></a></span></li>
 </ul>
 </details>}}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DiseasyRegionsNuts-validate_configuration"></a>}}
 \if{latex}{\out{\hypertarget{method-DiseasyRegionsNuts-validate_configuration}{}}}
 \subsection{\code{DiseasyRegionsNuts$validate_configuration()}}{
-  Check whether regions, adjacency, and demography are mutually consistent
+  Check whether area, adjacency, and demography are mutually consistent
 and complete under NUTS hierarchy semantics.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegionsNuts$validate_configuration(regions, adjacency, demography)}
+    \preformatted{DiseasyRegionsNuts$validate_configuration(area, adjacency, demography)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{regions}}{(\code{character()})\cr The geographic regions of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
+      \item{\code{area}}{(\code{character()})\cr The geographic area (list of regions) of interest. The specified regions must be available in the \code{demography} and \code{adjacency} data.}
       \item{\code{adjacency}}{(\code{data.frame(1)})\cr The adjacency (connectedness) of the regions. Effectively, the \code{adjacency} is a long-form of the adjacency-matrix\cr The \code{data.frame} must include the following columns:\cr - \code{from} (\code{character}): Region identifier.\cr - \code{to}   (\code{character}): Region identifier.\cr - \code{adjacency} (\code{numeric}): Strength of the connectedness.\cr The \code{from} and \code{to} columns must contain the same set of regions. For "movement" inputs, rows are normalised before deriving the Theta matrix. For "infection-flow" inputs, values are interpreted directly as the Theta matrix.}
       \item{\code{demography}}{(\code{data.frame(1)})\cr The demography of the population per region.\cr The \code{data.frame} must include the following columns:\cr * \code{region} (\code{character}) Region identifier.\cr * \code{...} Optional additional stratification columns (e.g. sex, ethnicity).\cr * \code{population} (\code{numeric}) Number of individuals in the group.}
     }
@@ -421,7 +421,7 @@ and complete under NUTS hierarchy semantics.
   Create a logical filter using NUTS hierarchy prefix matching.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{DiseasyRegionsNuts$region_filter(values, regions = self \%.\% regions)}
+    \preformatted{DiseasyRegionsNuts$region_filter(values, area = self \%.\% area)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -429,9 +429,9 @@ and complete under NUTS hierarchy semantics.
     \describe{
       \item{\code{values}}{(\code{character()})\cr
 Values to filter, typically NUTS codes.}
-      \item{\code{regions}}{(\code{character()} or \code{NULL})\cr
+      \item{\code{area}}{(\code{character()} or \code{NULL})\cr
 Region identifiers to match against. Defaults to the currently selected
-regions. If \code{NULL}, all values are matched.}
+area. If \code{NULL}, all values are matched.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/generate_adjacency_meta.Rd
+++ b/man/generate_adjacency_meta.Rd
@@ -4,10 +4,10 @@
 \alias{generate_adjacency_meta}
 \title{Generate adjacency data with Meta Social Connectedness}
 \usage{
-generate_adjacency_meta(regions = NULL)
+generate_adjacency_meta(area = NULL)
 }
 \arguments{
-\item{regions}{(\code{character()})\cr The geographic regions of interest. If \code{NULL}, all regions are returned.}
+\item{area}{(\code{character()})\cr The geographic area (list of regions) of interest. If \code{NULL}, all regions are returned.}
 }
 \value{
 (\code{data.frame(1)})\cr The adjacency (connectedness) of the regions. Effectively, the \code{adjacency} is a long-form of the adjacency-matrix\cr The \code{data.frame} must include the following columns:\cr - \code{from} (\code{character}): Region identifier.\cr - \code{to}   (\code{character}): Region identifier.\cr - \code{adjacency} (\code{numeric}): Strength of the connectedness.\cr
@@ -18,7 +18,7 @@ Index.
 }
 \examples{
 \dontrun{
-adjacency_meta_nordic <- generate_adjacency_meta(regions = c("DK", "FI", "IS", "NO", "SE"))
+adjacency_meta_nordic <- generate_adjacency_meta(area = c("DK", "FI", "IS", "NO", "SE"))
 }
 }
 \keyword{data-generators}

--- a/man/generate_contact_basis.Rd
+++ b/man/generate_contact_basis.Rd
@@ -4,10 +4,10 @@
 \alias{generate_contact_basis}
 \title{Generate contact-basis data}
 \usage{
-generate_contact_basis(regions = NULL)
+generate_contact_basis(area = NULL)
 }
 \arguments{
-\item{regions}{(\code{character()})\cr The geographic regions of interest. If \code{NULL}, all regions are returned.}
+\item{area}{(\code{character()})\cr The geographic area (list of regions) of interest. If \code{NULL}, all regions are returned.}
 }
 \value{
 A named list of contact-basis objects, using the current package data

--- a/man/generate_demography.Rd
+++ b/man/generate_demography.Rd
@@ -5,13 +5,13 @@
 \title{Generate country-level demography data}
 \usage{
 generate_demography(
-  regions = NULL,
+  area = NULL,
   year = 2020L,
   idb_zip = "https://www.census.gov/data-tools/demo/data/idb/dataset/idbzip.zip"
 )
 }
 \arguments{
-\item{regions}{(\code{character()})\cr The geographic regions of interest. If \code{NULL}, all regions are returned.}
+\item{area}{(\code{character()})\cr The geographic area (list of regions) of interest. If \code{NULL}, all regions are returned.}
 
 \item{year}{(\code{integer(1)})\cr
 The year to keep from the source data.}
@@ -28,7 +28,7 @@ U.S. Census Bureau International Database.
 }
 \examples{
 \dontrun{
-demography <- generate_demography(regions = c("DK", "FI", "IS", "NO", "SE"))
+demography <- generate_demography(area = c("DK", "FI", "IS", "NO", "SE"))
 }
 }
 \keyword{data-generators}

--- a/man/generate_demography_nuts3.Rd
+++ b/man/generate_demography_nuts3.Rd
@@ -4,10 +4,10 @@
 \alias{generate_demography_nuts3}
 \title{Generate NUTS3 demography data}
 \usage{
-generate_demography_nuts3(regions = NULL, cache = FALSE, output_nuts = FALSE)
+generate_demography_nuts3(area = NULL, cache = FALSE, output_nuts = FALSE)
 }
 \arguments{
-\item{regions}{(\code{character()})\cr The geographic regions of interest. If \code{NULL}, all regions are returned.}
+\item{area}{(\code{character()})\cr The geographic area (list of regions) of interest. If \code{NULL}, all regions are returned.}
 
 \item{cache}{(\code{logical(1)})\cr
 Passed to \code{\link[eurostat:get_eurostat]{eurostat::get_eurostat()}}.}
@@ -24,7 +24,7 @@ from Eurostat dataset \code{demo_r_pjangrp3}.
 }
 \examples{
 \dontrun{
-nuts_data <- generate_demography_nuts3(regions = c("DK", "FI", "IS", "NO", "SE"))
+nuts_data <- generate_demography_nuts3(area = c("DK", "FI", "IS", "NO", "SE"))
 }
 }
 \keyword{data-generators}

--- a/pak.lock
+++ b/pak.lock
@@ -1134,15 +1134,5 @@
       "version": "3.0.0",
       "binary": true
     }
-  ],
-  "sysreqs": {
-    "os": "linux",
-    "distribution": "ubuntu",
-    "version": "24.04",
-    "url": {},
-    "pre_install": "apt-get -y update",
-    "install_scripts": "apt-get -y install pandoc libx11-dev git libcurl4-openssl-dev libssl-dev xz-utils cmake make libuv1-dev libgit2-dev zlib1g-dev libgeos-dev libproj-dev libsqlite3-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libwebp-dev libabsl-dev libgdal-dev gdal-bin libicu-dev libfontconfig1-dev libfribidi-dev libharfbuzz-dev libudunits2-dev libnode-dev libxml2-dev",
-    "post_install": {},
-    "packages": ["pandoc", "libx11-dev", "git", "libcurl4-openssl-dev", "libssl-dev", "xz-utils", "cmake", "make", "libuv1-dev", "libgit2-dev", "zlib1g-dev", "libgeos-dev", "libproj-dev", "libsqlite3-dev", "libfreetype6-dev", "libjpeg-dev", "libpng-dev", "libtiff-dev", "libwebp-dev", "libabsl-dev", "libgdal-dev", "gdal-bin", "libicu-dev", "libfontconfig1-dev", "libfribidi-dev", "libharfbuzz-dev", "libudunits2-dev", "libnode-dev", "libxml2-dev"]
-  }
+  ]
 }

--- a/tests/testthat/test-DiseasyPopulation.R
+++ b/tests/testthat/test-DiseasyPopulation.R
@@ -9,8 +9,8 @@ test_that("initialize works", {
 
 
   # Set age stratification during loading (requires region module)
-  region <- DiseasyRegions$new(demography = demography_nordic)
-  population <- DiseasyPopulation$new(age_cuts_lower = c(20, 40, 60), region = region)
+  regions <- DiseasyRegions$new(demography = demography_nordic)
+  population <- DiseasyPopulation$new(age_cuts_lower = c(20, 40, 60), regions = regions)
   expect_identical(population %.% age_cuts_lower, c(20L, 40L, 60L))
   expect_null(population %.% regional_stratification)
 
@@ -18,7 +18,7 @@ test_that("initialize works", {
 
 
   # Set spatial stratification during loading (requires region module)
-  population <- DiseasyPopulation$new(regional_stratification = "region", region = region)
+  population <- DiseasyPopulation$new(regional_stratification = "region", regions = regions)
   expect_identical(population %.% age_cuts_lower, 0L)
   expect_identical(population %.% regional_stratification, "region")
 
@@ -29,8 +29,8 @@ test_that("initialize works", {
 test_that("$stratify_age() works", {
 
   # Creating an empty module
-  region <- DiseasyRegions$new(demography = demography_nordic)
-  population <- DiseasyPopulation$new(region = region)
+  regions <- DiseasyRegions$new(demography = demography_nordic)
+  population <- DiseasyPopulation$new(regions = regions)
   expect_identical(population %.% age_cuts_lower, 0L)
   hash_new_instance <- population$hash # Store the current hash
 
@@ -53,18 +53,18 @@ test_that("$stratify_age() works", {
 test_that("age stratification must be subset of `demography` age groups", {
 
   # Create region modules with inconsistent age groups
-  region <- DiseasyRegions$new(
+  regions <- DiseasyRegions$new(
     demography = demography_nordic |>
       dplyr::filter(.data$region == "DK" | (.data$region == "SE" & .data$age < 50))
   )
 
-  region_nuts <- DiseasyRegionsNuts$new(
+  regions_nuts <- DiseasyRegionsNuts$new(
     demography = demography_nordic_nuts3 |>
       dplyr::filter(startsWith(.data$region, "DK") | (startsWith(.data$region, "SE") & .data$age_group < "50"))
   )
 
-  population      <- DiseasyPopulation$new(region = region)
-  population_nuts <- DiseasyPopulation$new(region = region_nuts)
+  population      <- DiseasyPopulation$new(regions = regions)
+  population_nuts <- DiseasyPopulation$new(regions = regions_nuts)
 
   # Error should only occur when age stratifications are requested
   population$stratify_age(c(0, 30)) # No issue since inconsistency is for 50+
@@ -85,15 +85,15 @@ test_that("age stratification must be subset of `demography` age groups", {
     regexp = "The age groups in the demography"
   )
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("$stratify_regions() works", {
 
   # Creating an empty module
-  region <- DiseasyRegions$new()
-  population <- DiseasyPopulation$new(region = region)
+  regions <- DiseasyRegions$new()
+  population <- DiseasyPopulation$new(regions = regions)
   expect_null(population %.% regional_stratification)
   hash_new_instance <- population$hash # Store the current hash
 
@@ -112,13 +112,13 @@ test_that("$stratify_regions() works", {
   )
 
   rm(population)
-  rm(region)
+  rm(regions)
 
 
 
   # `DiseasyRegionsNuts` supports "null" or NUTS levels depending on loaded demography
-  region_nuts <- DiseasyRegionsNuts$new(demography = demography_nordic_nuts3)
-  population <- DiseasyPopulation$new(region = region_nuts)
+  regions_nuts <- DiseasyRegionsNuts$new(demography = demography_nordic_nuts3)
+  population <- DiseasyPopulation$new(regions = regions_nuts)
   hash_new_instance <- population$hash # Store the current hash
 
 
@@ -144,7 +144,7 @@ test_that("$stratify_regions() works", {
 
 
   rm(population)
-  rm(region_nuts)
+  rm(regions_nuts)
 })
 
 
@@ -179,11 +179,11 @@ test_that("$groups works", {
   )
 
   # Load region module
-  region = DiseasyRegions$new(
-    regions = c("DK", "SE", "NO"),
+  regions = DiseasyRegions$new(
+    area = c("DK", "SE", "NO"),
     demography = demography_nordic
   )
-  population$load_module(region)
+  population$load_module(regions)
 
   expect_no_error(population$stratify_regions(regional_stratification = "region"))
   expect_identical(
@@ -196,12 +196,12 @@ test_that("$groups works", {
 
 
   # We now test with the NUTS region module
-  region_nuts <- DiseasyRegionsNuts$new(
-    regions = c("DK", "SE", "NO"),
+  regions_nuts <- DiseasyRegionsNuts$new(
+    area = c("DK", "SE", "NO"),
     demography = demography_nordic_nuts3
   )
 
-  population$load_module(region_nuts)
+  population$load_module(regions_nuts)
 
   # This should break the configuration, so we should get an error when trying to get groups
   # (since stratification is still "region" but we now have a NUTS regions module loaded)
@@ -222,7 +222,7 @@ test_that("$groups works", {
 
 
   # To test lower nuts level, we restrict the scope to DK
-  population$regions$set_regions("DK")
+  population$regions$set_area("DK")
   expect_identical(
     population$groups,
     tidyr::expand_grid(
@@ -241,8 +241,8 @@ test_that("$groups works", {
   )
 
   rm(population)
-  rm(region)
-  rm(region_nuts)
+  rm(regions)
+  rm(regions_nuts)
 })
 
 
@@ -268,14 +268,14 @@ test_that("$describe() works", {
   population <- DiseasyPopulation$new()
   expect_no_error(withr::with_output_sink(nullfile(), population$describe()))
 
-  region = DiseasyRegions$new(regions = c("DK", "SE", "NO"), demography = demography_nordic)
-  population$load_module(region)
+  regions = DiseasyRegions$new(area = c("DK", "SE", "NO"), demography = demography_nordic)
+  population$load_module(regions)
   population$stratify_regions("region")
   expect_no_error(withr::with_output_sink(nullfile(), population$describe()))
 
   population$stratify_age(c(0, 20, 40))
   expect_no_error(withr::with_output_sink(nullfile(), population$describe()))
 
-  rm(region)
+  rm(regions)
   rm(population)
 })

--- a/tests/testthat/test-DiseasyRegions.R
+++ b/tests/testthat/test-DiseasyRegions.R
@@ -231,11 +231,11 @@ test_that("$region_filter() works", {
   )
 
   expect_identical(
-    regions$region_filter(values = c("north", "south"), area = "north"),
+    regions$region_filter(values = c("north", "south"), target_area = "north"),
     c(TRUE, FALSE)
   )
   expect_identical(
-    regions$region_filter(values = c("north", "south"), area = NULL),
+    regions$region_filter(values = c("north", "south"), target_area = NULL),
     c(TRUE, TRUE)
   )
 

--- a/tests/testthat/test-DiseasyRegions.R
+++ b/tests/testthat/test-DiseasyRegions.R
@@ -358,7 +358,13 @@ test_that("$regions_at_stratification() tries to guess regions even if `regions`
 
 
   # Intersection of demography and adjacency
-  regions$set_adjacency(dplyr::filter(adjacency_meta_nordic, .data$from %in% c("DK", "SE"), .data$to %in% c("DK", "SE")))
+  regions$set_adjacency(
+    dplyr::filter(
+      adjacency_meta_nordic,
+      .data$from %in% c("DK", "SE"),
+      .data$to %in% c("DK", "SE")
+    )
+  )
 
   expect_identical(
     regions$regions_at_stratification(regional_stratification = "region"),
@@ -389,7 +395,7 @@ test_that("active binding: area works", {
   expect_identical(regions %.% area, "north")
 
   regions_error <- tryCatch(
-    regions$area <- "south",                                                                                          # nolint: implicit_assignment_linter
+    regions$area <- "south",                                                                                            # nolint: implicit_assignment_linter
     error = \(e) e
   )
   expect_identical(regions_error, simpleError("`$area` is read only"))
@@ -410,7 +416,7 @@ test_that("active binding: adjacency works", {
   expect_identical(nrow(regions %.% adjacency), 1L)
 
   adjacency_error <- tryCatch(
-    regions$adjacency <- test_adjacency,                                                                                 # nolint: implicit_assignment_linter
+    regions$adjacency <- test_adjacency,                                                                                # nolint: implicit_assignment_linter
     error = \(e) e
   )
   expect_identical(adjacency_error, simpleError("`$adjacency` is read only"))
@@ -431,7 +437,7 @@ test_that("active binding: demography works", {
   expect_identical(regions %.% demography %.% region, "north")
 
   demography_error <- tryCatch(
-    regions$demography <- test_demography,                                                                               # nolint: implicit_assignment_linter
+    regions$demography <- test_demography,                                                                              # nolint: implicit_assignment_linter
     error = \(e) e
   )
   expect_identical(demography_error, simpleError("`$demography` is read only"))

--- a/tests/testthat/test-DiseasyRegions.R
+++ b/tests/testthat/test-DiseasyRegions.R
@@ -47,15 +47,15 @@ test_that("Empty initialize works", {
 })
 
 
-test_that("`$set_regions()`` works", {
+test_that("`$set_area()`` works", {
 
   region_1 <- DiseasyRegions$new()
-  region_1$set_regions(c("north", "south"))
+  region_1$set_area(c("north", "south"))
 
   region_2 <- DiseasyRegions$new()
-  region_2$set_regions(c("south", "north"))
+  region_2$set_area(c("south", "north"))
 
-  expect_identical(region_1 %.% regions, region_2 %.% regions)
+  expect_identical(region_1 %.% area, region_2 %.% area)
   expect_identical(region_1 %.% hash, region_2 %.% hash)
 
   rm(region_1)
@@ -112,37 +112,37 @@ test_that("Malformed inputs to initialize works", {
   expect_error(
     checkmate_err_msg(
       DiseasyRegions$new(
-        regions = "non-existent-region",
+        area = "non-existent-region",
         adjacency = test_adjacency,
         demography = test_demography
       )
     ),
     class = "simpleError",
-    regexp = "`regions` and `adjacency` must contain at least one common region."
+    regexp = "`area` and `adjacency` must contain at least one common region."
   )
 
   expect_error(
     checkmate_err_msg(
       DiseasyRegions$new(
-        regions = "north",
+        area = "north",
         adjacency = dplyr::filter(test_adjacency, .data$from != "north", .data$to != "north"),
         demography = test_demography
       )
     ),
     class = "simpleError",
-    regexp = "`regions` and `adjacency` must contain at least one common region."
+    regexp = "`area` and `adjacency` must contain at least one common region."
   )
 
   expect_error(
     checkmate_err_msg(
       DiseasyRegions$new(
-        regions = "north",
+        area = "north",
         adjacency = test_adjacency,
         demography = dplyr::filter(test_demography, .data$region != "north")
       )
     ),
     class = "simpleError",
-    regexp = "`regions` and `demography` must contain at least one common region."
+    regexp = "`area` and `demography` must contain at least one common region."
   )
 
   expect_error(
@@ -160,60 +160,60 @@ test_that("Malformed inputs to initialize works", {
 
 test_that("Non-empty initialize works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  expect_identical(region %.% regions, "north")
-  expect_identical(region %.% demography %.% region, "north")
-  expect_identical(sum(region %.% demography %.% population), 100)
+  expect_identical(regions %.% area, "north")
+  expect_identical(regions %.% demography %.% region, "north")
+  expect_identical(sum(regions %.% demography %.% population), 100)
 
-  expect_identical(nrow(region %.% adjacency), 1L)
-  expect_identical(region %.% adjacency %.% from, "north")
-  expect_identical(region %.% adjacency %.% to, "north")
+  expect_identical(nrow(regions %.% adjacency), 1L)
+  expect_identical(regions %.% adjacency %.% from, "north")
+  expect_identical(regions %.% adjacency %.% to, "north")
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("Setters are commutative", {
 
   # Permutaiton 1
-  region <- DiseasyRegions$new()
-  region$set_regions(c("north", "south"))
-  region$set_adjacency(test_adjacency)
-  region$set_demography(test_demography)
-  hash_1 <- region$hash
-  rm(region)
+  regions <- DiseasyRegions$new()
+  regions$set_area(c("north", "south"))
+  regions$set_adjacency(test_adjacency)
+  regions$set_demography(test_demography)
+  hash_1 <- regions$hash
+  rm(regions)
 
 
   # Permutation 2
-  region <- DiseasyRegions$new()
-  region$set_adjacency(test_adjacency)
-  region$set_regions(c("north", "south"))
-  region$set_demography(test_demography)
-  hash_2 <- region$hash
-  rm(region)
+  regions <- DiseasyRegions$new()
+  regions$set_adjacency(test_adjacency)
+  regions$set_area(c("north", "south"))
+  regions$set_demography(test_demography)
+  hash_2 <- regions$hash
+  rm(regions)
 
 
   # Permutation 3
-  region <- DiseasyRegions$new()
-  region$set_adjacency(test_adjacency)
-  region$set_demography(test_demography)
-  region$set_regions(c("north", "south"))
-  hash_3 <- region$hash
-  rm(region)
+  regions <- DiseasyRegions$new()
+  regions$set_adjacency(test_adjacency)
+  regions$set_demography(test_demography)
+  regions$set_area(c("north", "south"))
+  hash_3 <- regions$hash
+  rm(regions)
 
 
   # Permutation 4
-  region <- DiseasyRegions$new()
-  region$set_demography(test_demography)
-  region$set_adjacency(test_adjacency)
-  region$set_regions(c("north", "south"))
-  hash_4 <- region$hash
-  rm(region)
+  regions <- DiseasyRegions$new()
+  regions$set_demography(test_demography)
+  regions$set_adjacency(test_adjacency)
+  regions$set_area(c("north", "south"))
+  hash_4 <- regions$hash
+  rm(regions)
 
   expect_length(
     unique(c(hash_1, hash_2, hash_3, hash_4)),
@@ -224,72 +224,72 @@ test_that("Setters are commutative", {
 
 test_that("$region_filter() works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
   expect_identical(
-    region$region_filter(values = c("north", "south"), regions = "north"),
+    regions$region_filter(values = c("north", "south"), area = "north"),
     c(TRUE, FALSE)
   )
   expect_identical(
-    region$region_filter(values = c("north", "south"), regions = NULL),
+    regions$region_filter(values = c("north", "south"), area = NULL),
     c(TRUE, TRUE)
   )
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("region filtering works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  checkmate::expect_subset(region %.% demography %.% region, "north")
-  checkmate::expect_subset(region %.% adjacency %.% from, "north")
-  checkmate::expect_subset(region %.% adjacency %.% to, "north")
+  checkmate::expect_subset(regions %.% demography %.% region, "north")
+  checkmate::expect_subset(regions %.% adjacency %.% from, "north")
+  checkmate::expect_subset(regions %.% adjacency %.% to, "north")
 
-  region$set_regions(c("north", "east"))
-  checkmate::expect_subset(region %.% demography %.% region, c("north", "east"))
-  checkmate::expect_subset(region %.% adjacency %.% from, c("north", "east"))
-  checkmate::expect_subset(region %.% adjacency %.% to, c("north", "east"))
+  regions$set_area(c("north", "east"))
+  checkmate::expect_subset(regions %.% demography %.% region, c("north", "east"))
+  checkmate::expect_subset(regions %.% adjacency %.% from, c("north", "east"))
+  checkmate::expect_subset(regions %.% adjacency %.% to, c("north", "east"))
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("regions are matched exactly", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  expect_false("north_subregion" %in% region$demography$region)
-  expect_false("north_subregion" %in% region$adjacency$from)
-  expect_false("north_subregion" %in% region$adjacency$to)
+  expect_false("north_subregion" %in% regions$demography$region)
+  expect_false("north_subregion" %in% regions$adjacency$from)
+  expect_false("north_subregion" %in% regions$adjacency$to)
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("adjacency matrix normalisation works", {
 
   region_1 <- DiseasyRegions$new(
-    regions = c("north", "south", "east", "north_subregion"),
+    area = c("north", "south", "east", "north_subregion"),
     adjacency = test_adjacency,
     demography = test_demography
   )
 
   region_2 <- DiseasyRegions$new(
-    regions = c("north", "south", "east", "north_subregion"),
+    area = c("north", "south", "east", "north_subregion"),
     adjacency = dplyr::mutate(test_adjacency, "adjacency" = 2 * .data$adjacency),
     demography = test_demography
   )
@@ -320,140 +320,140 @@ test_that("adjacency data must be complete", {
 
 test_that("`demography` data set works with `DiseasyRegions`", {
 
-  region <- DiseasyRegions$new()
-  expect_no_error(region$set_demography(demography_nordic))
-  expect_no_error(region$set_regions(c("DK", "SE")))
+  regions <- DiseasyRegions$new()
+  expect_no_error(regions$set_demography(demography_nordic))
+  expect_no_error(regions$set_area(c("DK", "SE")))
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("`demography_nuts3` data set works with `DiseasyRegions`", {
 
-  region <- DiseasyRegions$new()
-  expect_no_error(region$set_demography(demography_nordic_nuts3))
-  expect_no_error(region$set_regions(c("DK011", "DK012")))
+  regions <- DiseasyRegions$new()
+  expect_no_error(regions$set_demography(demography_nordic_nuts3))
+  expect_no_error(regions$set_area(c("DK011", "DK012")))
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("$regions_at_stratification() tries to guess regions even if `regions` are not configured", {
 
   # No information
-  region <- DiseasyRegions$new()
+  regions <- DiseasyRegions$new()
 
   expect_null(
-    region$regions_at_stratification(regional_stratification = "region")
+    regions$regions_at_stratification(regional_stratification = "region")
   )
 
 
   # Only demography
-  region$set_demography(demography_nordic)
+  regions$set_demography(demography_nordic)
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "region"),
+    regions$regions_at_stratification(regional_stratification = "region"),
     sort(unique(demography_nordic$region))
   )
 
 
   # Intersection of demography and adjacency
-  region$set_adjacency(dplyr::filter(adjacency_meta_nordic, .data$from %in% c("DK", "SE"), .data$to %in% c("DK", "SE")))
+  regions$set_adjacency(dplyr::filter(adjacency_meta_nordic, .data$from %in% c("DK", "SE"), .data$to %in% c("DK", "SE")))
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "region"),
+    regions$regions_at_stratification(regional_stratification = "region"),
     c("DK", "SE")
   )
 
 
   # With regions defined
-  region$set_regions("DK")
+  regions$set_area("DK")
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "region"),
+    regions$regions_at_stratification(regional_stratification = "region"),
     "DK"
   )
 
-  rm(region)
+  rm(regions)
 })
 
 
-test_that("active binding: regions works", {
+test_that("active binding: area works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  expect_identical(region %.% regions, "north")
+  expect_identical(regions %.% area, "north")
 
   regions_error <- tryCatch(
-    region$regions <- "south",                                                                                          # nolint: implicit_assignment_linter
+    regions$area <- "south",                                                                                          # nolint: implicit_assignment_linter
     error = \(e) e
   )
-  expect_identical(regions_error, simpleError("`$regions` is read only"))
-  expect_identical(region %.% regions, "north")
+  expect_identical(regions_error, simpleError("`$area` is read only"))
+  expect_identical(regions %.% area, "north")
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("active binding: adjacency works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  expect_identical(nrow(region %.% adjacency), 1L)
+  expect_identical(nrow(regions %.% adjacency), 1L)
 
   adjacency_error <- tryCatch(
-    region$adjacency <- test_adjacency,                                                                                 # nolint: implicit_assignment_linter
+    regions$adjacency <- test_adjacency,                                                                                 # nolint: implicit_assignment_linter
     error = \(e) e
   )
   expect_identical(adjacency_error, simpleError("`$adjacency` is read only"))
-  expect_identical(nrow(region %.% adjacency), 1L)
+  expect_identical(nrow(regions %.% adjacency), 1L)
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("active binding: demography works", {
 
-  region <- DiseasyRegions$new(
-    regions = "north",
+  regions <- DiseasyRegions$new(
+    area = "north",
     adjacency = test_adjacency,
     demography = test_demography
   )
 
-  expect_identical(region %.% demography %.% region, "north")
+  expect_identical(regions %.% demography %.% region, "north")
 
   demography_error <- tryCatch(
-    region$demography <- test_demography,                                                                               # nolint: implicit_assignment_linter
+    regions$demography <- test_demography,                                                                               # nolint: implicit_assignment_linter
     error = \(e) e
   )
   expect_identical(demography_error, simpleError("`$demography` is read only"))
-  expect_identical(region %.% demography %.% region, "north")
+  expect_identical(regions %.% demography %.% region, "north")
 
-  rm(region)
+  rm(regions)
 })
 
 
 test_that("$describe() works", {
 
-  region <- DiseasyRegions$new()
-  expect_no_error(withr::with_output_sink(nullfile(), region$describe()))
+  regions <- DiseasyRegions$new()
+  expect_no_error(withr::with_output_sink(nullfile(), regions$describe()))
 
-  region$set_regions("north")
-  expect_no_error(withr::with_output_sink(nullfile(), region$describe()))
+  regions$set_area("north")
+  expect_no_error(withr::with_output_sink(nullfile(), regions$describe()))
 
-  region$set_adjacency(test_adjacency)
-  expect_no_error(withr::with_output_sink(nullfile(), region$describe()))
+  regions$set_adjacency(test_adjacency)
+  expect_no_error(withr::with_output_sink(nullfile(), regions$describe()))
 
-  region$set_demography(test_demography)
-  expect_no_error(withr::with_output_sink(nullfile(), region$describe()))
+  regions$set_demography(test_demography)
+  expect_no_error(withr::with_output_sink(nullfile(), regions$describe()))
 
-  rm(region)
+  rm(regions)
 })

--- a/tests/testthat/test-DiseasyRegionsNuts.R
+++ b/tests/testthat/test-DiseasyRegionsNuts.R
@@ -192,11 +192,11 @@ test_that("$region_filter() works", {
   )
 
   expect_identical(
-    regions_nuts$region_filter(values = c("IS001", "IS002"), area = "IS001"),
+    regions_nuts$region_filter(values = c("IS001", "IS002"), target_area = "IS001"),
     c(TRUE, FALSE)
   )
   expect_identical(
-    regions_nuts$region_filter(values = c("IS001", "IS002"), area = NULL),
+    regions_nuts$region_filter(values = c("IS001", "IS002"), target_area = NULL),
     c(TRUE, TRUE)
   )
 

--- a/tests/testthat/test-DiseasyRegionsNuts.R
+++ b/tests/testthat/test-DiseasyRegionsNuts.R
@@ -38,52 +38,52 @@ test_that("Empty initialize works", {
 })
 
 
-test_that("`$set_regions()`` works", {
+test_that("`$set_area()`` works", {
 
-  region_1 <- DiseasyRegionsNuts$new()
-  region_1$set_regions(c("DK01", "DK02"))
+  regions_nuts_1 <- DiseasyRegionsNuts$new()
+  regions_nuts_1$set_area(c("DK01", "DK02"))
 
-  region_2 <- DiseasyRegionsNuts$new()
-  region_2$set_regions(c("DK02", "DK01"))
+  regions_nuts_2 <- DiseasyRegionsNuts$new()
+  regions_nuts_2$set_area(c("DK02", "DK01"))
 
-  expect_identical(region_1 %.% regions, region_2 %.% regions)
-  expect_identical(region_1 %.% hash, region_2 %.% hash)
+  expect_identical(regions_nuts_1 %.% area, regions_nuts_2 %.% area)
+  expect_identical(regions_nuts_1 %.% hash, regions_nuts_2 %.% hash)
 
-  rm(region_1)
-  rm(region_2)
+  rm(regions_nuts_1)
+  rm(regions_nuts_2)
 })
 
 
 test_that("`$set_adjacency()`` works", {
 
-  region_1 <- DiseasyRegionsNuts$new()
-  region_1$set_adjacency(test_adjacency)
+  regions_nuts_1 <- DiseasyRegionsNuts$new()
+  regions_nuts_1$set_adjacency(test_adjacency)
 
-  region_2 <- DiseasyRegionsNuts$new()
-  region_2$set_adjacency(test_adjacency[sample(nrow(test_adjacency)), ])
+  regions_nuts_2 <- DiseasyRegionsNuts$new()
+  regions_nuts_2$set_adjacency(test_adjacency[sample(nrow(test_adjacency)), ])
 
-  expect_identical(region_1 %.% adjacency, region_2 %.% adjacency)
-  expect_identical(region_1 %.% infection_flow_matrix, region_2 %.% infection_flow_matrix)
-  expect_identical(region_1 %.% hash, region_2 %.% hash)
+  expect_identical(regions_nuts_1 %.% adjacency, regions_nuts_2 %.% adjacency)
+  expect_identical(regions_nuts_1 %.% infection_flow_matrix, regions_nuts_2 %.% infection_flow_matrix)
+  expect_identical(regions_nuts_1 %.% hash, regions_nuts_2 %.% hash)
 
-  rm(region_1)
-  rm(region_2)
+  rm(regions_nuts_1)
+  rm(regions_nuts_2)
 })
 
 
 test_that("`$set_demography()`` works", {
 
-  region_1 <- DiseasyRegionsNuts$new()
-  region_1$set_demography(demography_nordic_nuts3)
+  regions_nuts_1 <- DiseasyRegionsNuts$new()
+  regions_nuts_1$set_demography(demography_nordic_nuts3)
 
-  region_2 <- DiseasyRegionsNuts$new()
-  region_2$set_demography(demography_nordic_nuts3[sample(nrow(demography_nordic_nuts3)), ])
+  regions_nuts_2 <- DiseasyRegionsNuts$new()
+  regions_nuts_2$set_demography(demography_nordic_nuts3[sample(nrow(demography_nordic_nuts3)), ])
 
-  expect_identical(region_1 %.% demography, region_2 %.% demography)
-  expect_identical(region_1 %.% hash, region_2 %.% hash)
+  expect_identical(regions_nuts_1 %.% demography, regions_nuts_2 %.% demography)
+  expect_identical(regions_nuts_1 %.% hash, regions_nuts_2 %.% hash)
 
-  rm(region_1)
-  rm(region_2)
+  rm(regions_nuts_1)
+  rm(regions_nuts_2)
 })
 
 
@@ -92,7 +92,7 @@ test_that("Malformed inputs to initialize works", {
   expect_error(
     checkmate_err_msg(
       DiseasyRegionsNuts$new(
-        regions = "IS001",
+        area = "IS001",
         adjacency = dplyr::filter(test_adjacency, .data$from != "IS001", .data$to != "IS001")
       )
     ),
@@ -103,7 +103,7 @@ test_that("Malformed inputs to initialize works", {
   expect_error(
     checkmate_err_msg(
       DiseasyRegionsNuts$new(
-        regions = "IS001",
+        area = "IS001",
         adjacency = test_adjacency,
         demography = dplyr::filter(demography_nordic_nuts3, .data$region != "IS001")
       )
@@ -117,24 +117,24 @@ test_that("Malformed inputs to initialize works", {
 
 test_that("Non-empty initialize works", {
 
-  region <- DiseasyRegionsNuts$new(
-    regions = "IS001",
+  regions_nuts <- DiseasyRegionsNuts$new(
+    area = "IS001",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
-  expect_identical(region %.% regions, "IS001")
-  expect_identical(unique(region %.% demography %.% region), "IS001")
+  expect_identical(regions_nuts %.% area, "IS001")
+  expect_identical(unique(regions_nuts %.% demography %.% region), "IS001")
   expect_identical(
-    sum(region %.% demography %.% population),
+    sum(regions_nuts %.% demography %.% population),
     sum(dplyr::pull(dplyr::filter(demography_nordic_nuts3, .data$region == "IS001"), "population"))
   )
 
-  expect_identical(nrow(region %.% adjacency), 1L)
-  expect_identical(region %.% adjacency %.% from, "IS001")
-  expect_identical(region %.% adjacency %.% to, "IS001")
+  expect_identical(nrow(regions_nuts %.% adjacency), 1L)
+  expect_identical(regions_nuts %.% adjacency %.% from, "IS001")
+  expect_identical(regions_nuts %.% adjacency %.% to, "IS001")
 
-  rm(region)
+  rm(regions_nuts)
 })
 
 
@@ -142,39 +142,39 @@ test_that("Non-empty initialize works", {
 test_that("Setters are commutative", {
 
   # Permutaiton 1
-  region <- DiseasyRegionsNuts$new()
-  region$set_regions(c("IS001", "IS002"))
-  region$set_adjacency(test_adjacency)
-  region$set_demography(demography_nordic_nuts3)
-  hash_1 <- region$hash
-  rm(region)
+  regions_nuts <- DiseasyRegionsNuts$new()
+  regions_nuts$set_area(c("IS001", "IS002"))
+  regions_nuts$set_adjacency(test_adjacency)
+  regions_nuts$set_demography(demography_nordic_nuts3)
+  hash_1 <- regions_nuts$hash
+  rm(regions_nuts)
 
 
   # Permutation 2
-  region <- DiseasyRegionsNuts$new()
-  region$set_adjacency(test_adjacency)
-  region$set_regions(c("IS001", "IS002"))
-  region$set_demography(demography_nordic_nuts3)
-  hash_2 <- region$hash
-  rm(region)
+  regions_nuts <- DiseasyRegionsNuts$new()
+  regions_nuts$set_adjacency(test_adjacency)
+  regions_nuts$set_area(c("IS001", "IS002"))
+  regions_nuts$set_demography(demography_nordic_nuts3)
+  hash_2 <- regions_nuts$hash
+  rm(regions_nuts)
 
 
   # Permutation 3
-  region <- DiseasyRegionsNuts$new()
-  region$set_adjacency(test_adjacency)
-  region$set_demography(demography_nordic_nuts3)
-  region$set_regions(c("IS001", "IS002"))
-  hash_3 <- region$hash
-  rm(region)
+  regions_nuts <- DiseasyRegionsNuts$new()
+  regions_nuts$set_adjacency(test_adjacency)
+  regions_nuts$set_demography(demography_nordic_nuts3)
+  regions_nuts$set_area(c("IS001", "IS002"))
+  hash_3 <- regions_nuts$hash
+  rm(regions_nuts)
 
 
   # Permutation 4
-  region <- DiseasyRegionsNuts$new()
-  region$set_demography(demography_nordic_nuts3)
-  region$set_adjacency(test_adjacency)
-  region$set_regions(c("IS001", "IS002"))
-  hash_4 <- region$hash
-  rm(region)
+  regions_nuts <- DiseasyRegionsNuts$new()
+  regions_nuts$set_demography(demography_nordic_nuts3)
+  regions_nuts$set_adjacency(test_adjacency)
+  regions_nuts$set_area(c("IS001", "IS002"))
+  hash_4 <- regions_nuts$hash
+  rm(regions_nuts)
 
   expect_length(
     unique(c(hash_1, hash_2, hash_3, hash_4)),
@@ -185,131 +185,131 @@ test_that("Setters are commutative", {
 
 test_that("$region_filter() works", {
 
-  region <- DiseasyRegionsNuts$new(
-    regions = "IS001",
+  regions_nuts <- DiseasyRegionsNuts$new(
+    area = "IS001",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
   expect_identical(
-    region$region_filter(values = c("IS001", "IS002"), regions = "IS001"),
+    regions_nuts$region_filter(values = c("IS001", "IS002"), area = "IS001"),
     c(TRUE, FALSE)
   )
   expect_identical(
-    region$region_filter(values = c("IS001", "IS002"), regions = NULL),
+    regions_nuts$region_filter(values = c("IS001", "IS002"), area = NULL),
     c(TRUE, TRUE)
   )
 
-  rm(region)
+  rm(regions_nuts)
 })
 
 
 test_that("region filtering works", {
 
-  region <- DiseasyRegionsNuts$new(
-    regions = "IS001",
+  regions_nuts <- DiseasyRegionsNuts$new(
+    area = "IS001",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
-  checkmate::expect_subset(region %.% demography %.% region, "IS001")
-  checkmate::expect_subset(region %.% adjacency %.% from, "IS001")
-  checkmate::expect_subset(region %.% adjacency %.% to, "IS001")
+  checkmate::expect_subset(regions_nuts %.% demography %.% region, "IS001")
+  checkmate::expect_subset(regions_nuts %.% adjacency %.% from, "IS001")
+  checkmate::expect_subset(regions_nuts %.% adjacency %.% to, "IS001")
 
-  region$set_regions(c("IS001", "IS002"))
-  checkmate::expect_subset(region %.% demography %.% region, c("IS001", "IS002"))
-  checkmate::expect_subset(region %.% adjacency %.% from, c("IS001", "IS002"))
-  checkmate::expect_subset(region %.% adjacency %.% to, c("IS001", "IS002"))
+  regions_nuts$set_area(c("IS001", "IS002"))
+  checkmate::expect_subset(regions_nuts %.% demography %.% region, c("IS001", "IS002"))
+  checkmate::expect_subset(regions_nuts %.% adjacency %.% from, c("IS001", "IS002"))
+  checkmate::expect_subset(regions_nuts %.% adjacency %.% to, c("IS001", "IS002"))
 
-  rm(region)
+  rm(regions_nuts)
 })
 
 
 test_that("adjacency matrix normalisation works", {
 
-  region_1 <- DiseasyRegionsNuts$new(
-    regions = c("IS001", "IS002"),
+  regions_nuts_1 <- DiseasyRegionsNuts$new(
+    area = c("IS001", "IS002"),
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
-  region_2 <- DiseasyRegionsNuts$new(
-    regions = c("IS001", "IS002"),
+  regions_nuts_2 <- DiseasyRegionsNuts$new(
+    area = c("IS001", "IS002"),
     adjacency = dplyr::mutate(test_adjacency, "adjacency" = 2 * .data$adjacency),
     demography = demography_nordic_nuts3
   )
 
   expect_equal(                                                                                                         # nolint: expect_identical_linter
-    region_1$infection_flow_matrix,
-    region_2$infection_flow_matrix,
+    regions_nuts_1$infection_flow_matrix,
+    regions_nuts_2$infection_flow_matrix,
     tolerance = 1e-10
   )
 
 
-  rm(region_1)
-  rm(region_2)
+  rm(regions_nuts_1)
+  rm(regions_nuts_2)
 })
 
 
 test_that("`demography` data set works with `DiseasyRegionsNuts`", {
 
-  region <- DiseasyRegionsNuts$new()
-  expect_no_error(region$set_demography(demography_nordic))
-  expect_no_error(region$set_regions(c("DK", "SE")))
+  regions_nuts <- DiseasyRegionsNuts$new()
+  expect_no_error(regions_nuts$set_demography(demography_nordic))
+  expect_no_error(regions_nuts$set_area(c("DK", "SE")))
 
-  rm(region)
+  rm(regions_nuts)
 })
 
 
 test_that("`demography_nordic_nuts3` data set works with `DiseasyRegionsNuts`", {
 
-  region <- DiseasyRegionsNuts$new()
-  expect_no_error(region$set_demography(demography_nordic_nuts3))
-  expect_no_error(region$set_regions(c("DK011", "DK012")))
+  regions_nuts <- DiseasyRegionsNuts$new()
+  expect_no_error(regions_nuts$set_demography(demography_nordic_nuts3))
+  expect_no_error(regions_nuts$set_area(c("DK011", "DK012")))
 
-  rm(region)
+  rm(regions_nuts)
 })
 
 test_that("Hierarchical regions works", {
 
-  region_0 <- DiseasyRegionsNuts$new(
-    regions = "IS",
+  regions_nuts_0 <- DiseasyRegionsNuts$new(
+    area = "IS",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
-  region_1 <- DiseasyRegionsNuts$new(
-    regions = "IS0",
+  regions_nuts_1 <- DiseasyRegionsNuts$new(
+    area = "IS0",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
-  region_2 <- DiseasyRegionsNuts$new(
-    regions = "IS00",
+  regions_nuts_2 <- DiseasyRegionsNuts$new(
+    area = "IS00",
     adjacency = test_adjacency,
     demography = demography_nordic_nuts3
   )
 
   # For Malta, NUTS "0", NUTS 1 and NUTS 2 are the same
   expect_identical(
-    region_0$demography,
-    region_1$demography
+    regions_nuts_0$demography,
+    regions_nuts_1$demography
   )
 
   expect_identical(
-    region_0$demography,
-    region_2$demography
+    regions_nuts_0$demography,
+    regions_nuts_2$demography
   )
 
-  rm(region_0)
-  rm(region_1)
-  rm(region_2)
+  rm(regions_nuts_0)
+  rm(regions_nuts_1)
+  rm(regions_nuts_2)
 })
 
 test_that("$regions_at_stratification() tries to guess regions even if `regions` are not configured", {
 
   # Only demography
-  region <- DiseasyRegionsNuts$new(
+  regions_nuts <- DiseasyRegionsNuts$new(
     demography = demography_nordic_nuts3
   )
 
@@ -322,21 +322,21 @@ test_that("$regions_at_stratification() tries to guess regions even if `regions`
     unique() |>
     sort()
 
-  expect_null(region %.% regions)
+  expect_null(regions_nuts %.% area)
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 0"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 0"),
     expected_nuts0
   )
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 3"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 3"),
     expected_nuts3
   )
 
 
   # Intersection of demography and adjacency
-  region$set_adjacency(
+  regions_nuts$set_adjacency(
     dplyr::filter(
       adjacency_meta_nordic_nuts,
       substr(.data$from, 1, 2) %in% c("DK", "SE"),
@@ -345,7 +345,7 @@ test_that("$regions_at_stratification() tries to guess regions even if `regions`
   )
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 0"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 0"),
     c("DK", "SE")
   )
 
@@ -356,16 +356,16 @@ test_that("$regions_at_stratification() tries to guess regions even if `regions`
     sort()
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 3"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 3"),
     expected_nuts3
   )
 
 
   # With regions defined
-  region$set_regions("DK")
+  regions_nuts$set_area("DK")
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 0"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 0"),
     "DK"
   )
 
@@ -376,9 +376,9 @@ test_that("$regions_at_stratification() tries to guess regions even if `regions`
     sort()
 
   expect_identical(
-    region$regions_at_stratification(regional_stratification = "NUTS 3"),
+    regions_nuts$regions_at_stratification(regional_stratification = "NUTS 3"),
     expected_nuts3
   )
 
-  rm(region)
+  rm(regions_nuts)
 })

--- a/vignettes/articles/diseasy-population.Rmd
+++ b/vignettes/articles/diseasy-population.Rmd
@@ -47,7 +47,7 @@ For `DiseasyPopulation`, this is done via `DiseasyRegions`[^1] which handles dem
 regions <- DiseasyRegionsNuts$new(
   demography = demography_nordic_nuts3, # Use demography data from EUROSTAT
   adjacency = adjacency_meta_nordic_nuts, # Use adjacency data from Meta
-  regions = "DK" # Restrict population of interest to Danish population
+  area = "DK" # Restrict population of interest to Danish population
 )
 
 regions
@@ -57,7 +57,7 @@ Once the scope of the population has been defined in `DiseasyRegions`, this can 
 `DiseasyPopulation` to handle the remaining configuration of the model population.
 
 ```{r load-regions}
-population <- DiseasyPopulation$new(region = regions)
+population <- DiseasyPopulation$new(regions = regions)
 
 population
 ```

--- a/vignettes/articles/diseasy-regions.Rmd
+++ b/vignettes/articles/diseasy-regions.Rmd
@@ -285,7 +285,7 @@ adjacency and demography data.
 ```{r change_regions}
 regions$set_area(area = c("DK", "SE"))
 
-regions %.% regions
+regions %.% area
 ```
 
 The active fields now reflect the updated scope.

--- a/vignettes/articles/diseasy-regions.Rmd
+++ b/vignettes/articles/diseasy-regions.Rmd
@@ -26,18 +26,15 @@ withr::local_options("tibble.print_min" = 5)
 # Overview
 
 The `DiseasyRegions` module defines the regional scope for the models.
-In addition, it provides a common place to define the demography available for those regions,
-and the adjacency between regions.
-
-The module is intentionally generic. Region identifiers are treated as ordinary character values and are matched
-exactly. This means that, e.g., the region `"north"` is not interpreted as a parent of `"north_subregion"`.
+In addition, it provides a common place to define the demography available for those areas,
+and the adjacency between regions within the areas.
 
 # Data structure
 
 `DiseasyRegions` uses three inputs:
 
-- `regions`: a `character` vector defining the selected region scope.
-- `demography`: a `data.frame` with one region column, optional stratification columns, and one population column.
+- `area`: a `character` vector defining the selected regional scope.
+- `demography`: a `data.frame` with one "region" column, optional stratification columns, and one population column.
 - `adjacency`: a `data.frame` describing connectedness between pairs of regions
   (see the [Regional adjacency](#regional-adjacency) section for further details).
 
@@ -208,27 +205,27 @@ The matrix is derived in three steps:
 
 # Creating a regional module
 
-A `DiseasyRegions` object can be created and then configured with the selected regions, demography, and adjacency
+A `DiseasyRegions` object can be created and then configured with the selected area, demography, and adjacency
 data. Each setter validates the candidate input before storing it.
 
 ```{r create_module}
-region <- DiseasyRegions$new()
+regions <- DiseasyRegions$new()
 
-region
+regions
 ```
 
 ```{r module_setters}
-region$set_regions(regions = c("DK", "SE", "NO", "FI"))
-region$set_demography(demography = demography_nordic)
-region$set_adjacency(adjacency = adjacency_meta_nordic)
+regions$set_area(area = c("DK", "SE", "NO", "FI"))
+regions$set_demography(demography = demography_nordic)
+regions$set_adjacency(adjacency = adjacency_meta_nordic)
 
-region
+regions
 ```
 
 The `?DiseasyRegions$demography` field returns demography filtered to the currently selected regions.
 
 ```{r filtered_demography}
-region %.% demography
+regions %.% demography
 ```
 
 Population totals can be computed directly from the filtered demography.
@@ -236,7 +233,7 @@ Population totals can be computed directly from the filtered demography.
 ```{r population_totals}
 aggregate(
   population ~ region,
-  data = region %.% demography,
+  data = regions %.% demography,
   FUN = sum
 )
 ```
@@ -245,16 +242,16 @@ The active bindings `?DiseasyRegions$adjacency` and `?DiseasyRegions$infection_f
 expose derived views of `adjacency` input after filtering to the selected regions.
 
 ```{r filtered_adjacency}
-region %.% adjacency
+regions %.% adjacency
 ```
 
 ```{r filtered_theta_matrix}
-region %.% infection_flow_matrix
+regions %.% infection_flow_matrix
 ```
 
 The module configuration can also be visualised via the `$plot()` method with or `plot()`.
 ```{r plot}
-plot(region)
+plot(regions)
 ```
 
 ## Regional module with hierarchical structure (NUTS)
@@ -262,47 +259,47 @@ plot(region)
 If you have demography and adjacency data for structured regions (such as NUTS), then `DiseasyRegionsNuts` can handle
 the nested data.
 ```{r create_module_nuts}
-region_nuts <- DiseasyRegionsNuts$new()
+regions_nuts <- DiseasyRegionsNuts$new()
 
-region_nuts
+regions_nuts
 ```
 
 ```{r nuts_module_setters}
-region_nuts$set_regions(regions = "DK")
-region_nuts$set_demography(demography = demography_nordic_nuts3)
-region_nuts$set_adjacency(adjacency = adjacency_meta_nordic_nuts)
+regions_nuts$set_area(area = "DK")
+regions_nuts$set_demography(demography = demography_nordic_nuts3)
+regions_nuts$set_adjacency(adjacency = adjacency_meta_nordic_nuts)
 
-region_nuts
+regions_nuts
 ```
 
 And again the module configuration can also be visualised with `plot()`.
 ```{r plot_nuts}
-plot(region_nuts)
+plot(regions_nuts)
 ```
 
 # Changing the selected regions
 
-The selected regional scope can be changed with `$set_regions()`. The new regions must be available in the stored
+The selected regional scope can be changed with `$set_area()`. The new regions must be available in the stored
 adjacency and demography data.
 
 ```{r change_regions}
-region$set_regions(regions = c("DK", "SE"))
+regions$set_area(area = c("DK", "SE"))
 
-region %.% regions
+regions %.% regions
 ```
 
 The active fields now reflect the updated scope.
 
 ```{r changed_demography}
-region %.% demography
+regions %.% demography
 ```
 
 ```{r changed_adjacency}
-region %.% adjacency
+regions %.% adjacency
 ```
 
 ```{r changed_theta_matrix}
-region %.% infection_flow_matrix
+regions %.% infection_flow_matrix
 ```
 
 
@@ -312,7 +309,7 @@ The module checks that selected regions are available in the stored demography a
 select a region that is not present in the data will fail.
 
 ```{r invalid_region}
-try(region$set_regions(regions = "DE"))
+try(DiseasyRegionsNuts$set_area(regions = "DE"))
 ```
 
 The adjacency data must also contain the same region identifiers in the `from` and `to` columns.
@@ -324,7 +321,7 @@ bad_adjacency <- data.frame(
   adjacency = c(1, 1)
 )
 
-try(region$set_adjacency(adjacency = bad_adjacency))
+try(regions$set_adjacency(adjacency = bad_adjacency))
 ```
 
 


### PR DESCRIPTION
 <!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
We currently use "regions" in several contexts.

1) "regions" is used for "DiseasyRegions"
2) "regions" is used for the geographical area of interest in the `DiseasyRegions`
3) "region" is used as columns in the `demography` and `adjacency` data.

This PR attempts to remove some of this ambiguity which I have been stumbling over during development

### Approach
The geographical area of interest in the `DiseasyRegions` is now renamed to "area"

`DiseasyRegions` is now consistently referred to as "regions" with an s.

This leads to a lot of changes, but these are all trivial

### Known issues
N/A


### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
